### PR TITLE
Provide UMLS CUI information for a subset of chemicals

### DIFF
--- a/src/hub/dataload/sources/umls/parse_drugbank.py
+++ b/src/hub/dataload/sources/umls/parse_drugbank.py
@@ -1,0 +1,30 @@
+# Parse DrugBank's XML file to map obsolete DB IDs
+
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+import pandas as pd
+
+def map_dbids(fname):
+    """Parse the DrugBank XML to determine obsolete DrugBank ID mappings to the
+    current DrugBank ID."""
+
+    tree = ET.parse(fname)
+    root = tree.getroot()
+
+    namespace = {"DB": "http://www.drugbank.ca"}
+
+    DB_ID_LEN = 7
+
+    res = defaultdict(list)
+    for drug in root.iterfind("DB:drug", namespace):
+        primary_id = drug.find("DB:drugbank-id[@primary='true']", namespace).text
+        assert primary_id.startswith("DB")
+
+        for uid in drug.iterfind("DB:drugbank-id", namespace):
+            id_val = uid.text
+
+            if id_val.startswith("DB") and len(id_val) == DB_ID_LEN:
+                res["primary_id"].append(primary_id)
+                res["other_id"].append(id_val)
+
+    return pd.DataFrame(res).drop_duplicates()

--- a/src/hub/dataload/sources/umls/parse_mesh.py
+++ b/src/hub/dataload/sources/umls/parse_mesh.py
@@ -1,0 +1,58 @@
+# Parse the MeSH source files for MeSH id to UNII mappings
+# Works for both desc and supp XML files
+
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+import pandas as pd
+
+def parse_file(fname):
+    """Parse XML version of MeSH (desc and supp files) to give MeSH ID to
+    UNII mappings."""
+
+    def cleanup(df):
+        """Filter to only concepts mappable to UNIIs.
+
+        Main types of identifiers seem to be:
+            1. "0" for empty fields (seem to be categories/families of
+                chemicals, which by definition do not have specific InChIKeys or
+                structures, so we can safely ignore these).
+            2. Things with "EC" numbers, which seem to be enzymes/gene products,
+                which we can also skip.
+            3. UNIIs, which are of length 10 and are uniquely mappable to InChIKeys
+            4. CAS numbers, which are less useful for converting to InChIKey.
+
+        At the moment only the UNIIs are kept.
+        """
+        return (df
+            .assign(
+                isunii = lambda df: df["uid"].str.match(r'^[A-Z0-9]{10}$')
+            )
+            .query("isunii")
+            .drop("isunii", axis=1)
+            .rename(columns={"uid": "unii"})
+        )
+
+    assert fname.endswith(".xml"), "File must be XML"
+    assert "desc" in fname or "supp" in fname, "Wrong files given"
+
+    # which tags to search for in the XML file
+    record = "{}Record".format(
+        "Descriptor" if "desc" in fname else "Supplemental"
+    )
+    record_ui = "{}UI".format(
+        "Descriptor" if "desc" in fname else "SupplementalRecord"
+    )
+
+    tree = ET.parse(fname)
+    root = tree.getroot()
+
+    res = defaultdict(list)
+    for concept in root.iterfind(record):
+        mesh_id = concept.find(record_ui).text
+
+        node = concept.find("ConceptList/Concept/RegistryNumber")
+        if node is not None:
+            res["mesh_id"].append(mesh_id)
+            res["uid"].append(node.text)
+
+    return cleanup(pd.DataFrame(res))

--- a/src/hub/dataload/sources/umls/umls_main.py
+++ b/src/hub/dataload/sources/umls/umls_main.py
@@ -1,0 +1,112 @@
+from collections import defaultdict
+
+import pandas as pd
+
+from parse_mesh import parse_file
+from parse_drugbank import map_dbids
+
+def read_umls(fname):
+    """Read through MRCONSO.RRF and extract relevant info.
+
+    Currently extracted information:
+        1. DrugBank ID
+        2. MeSH ID
+        3. UNII
+
+    Other data sources could be processed here, but diminishing returns kick
+    in very quickly (they provide redundant data).
+
+    For example, RxNorm mappings are almost a complete subset of the direct
+    UNII mappings.
+
+    Returns a pandas DataFrame with three columns.
+    """
+    res = defaultdict(list)
+    with open(fname, "r") as fin:
+        for line in fin:
+            vals = line.rstrip("\n").split("|")
+
+            cui, sab, code = vals[0], vals[11], vals[13]
+
+            if sab in {"DRUGBANK", "MSH", "MTHSPL", "NCI_FDA"}:
+                res["cui"].append(cui)
+                res["code"].append(code)
+                res["source"].append(sab)
+
+    return pd.DataFrame(res).drop_duplicates()
+
+def format_data(df, key, val):
+    """Format a two column result dataframe for output."""
+
+    return {
+        group: set(data[val])
+        for group, data in df.groupby(key)
+    }
+
+def load_data():
+
+    info = read_umls("data/MRCONSO.RRF")
+
+#-------------------------------------------------------------------------------
+
+    # some of the drugbank ids given in the UMLS are obsolete
+    # we need to map them to their current values
+
+    drugbank = (info
+        .query("source == 'DRUGBANK'")
+        .drop("source", axis=1)
+        .merge(
+            map_dbids("data/drugbank_full.xml"),
+            how="inner", left_on="code", right_on="other_id"
+        )
+        [["cui", "primary_id"]]
+        .rename(columns={"primary_id": "drugbank_id"})
+        .drop_duplicates()
+    )
+
+#-------------------------------------------------------------------------------
+
+    # direct CUI to UNII mappings are processed here
+
+    uniis = (info
+        .query("source in('MTHSPL', 'NCI_FDA')")
+        .assign(isunii = lambda df: df["code"].str.match(r'^[A-Z0-9]{10}$'))
+        .query("isunii")
+        [["cui", "code"]]
+        .rename(columns={"code": "unii"})
+        .drop_duplicates()
+    )
+
+#-------------------------------------------------------------------------------
+
+    # CUI to MeSH to UNII
+
+    mesh_uniis = (parse_file("data/desc2017.xml")
+        .append(parse_file("data/supp2017.xml"))
+        .merge(
+            info.query("source == 'MSH'"),
+            how="inner", left_on="mesh_id", right_on="code"
+        )
+        [["cui", "unii"]]
+        .drop_duplicates()
+    )
+
+#-------------------------------------------------------------------------------
+
+    # yield drugbank results
+    for key, val in format_data(drugbank, "drugbank_id", "cui"):
+        yield {
+            "_id": key, # drugbank_id
+            "umls": {
+                "cuis": val # a set of UMLS CUIs
+            }
+        }
+
+    # yield UNII results
+    for key, val in format_data(uniis.append(mesh_uniis), "unii", "cui"):
+        yield {
+            "_id": key, # UNII
+            "umls": {
+                "cuis": val # a set of UMLS CUIs
+            }
+        }


### PR DESCRIPTION
Processes the UMLS to determine CUIs for a subset of chemicals. Converts the CUIs to DrugBank or UNIIs as appropriate. Was unable to map to Inchikey due to lack of resources providing a dump of UNII to Inchikey mappings.

Where conflicts arise between different sources (e.g. MeSH and UMLS direct), the items are merged.