### PR TITLE
Refactor 'pharmgkb' and 'chebi' parsers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ src/config_prod.py
 src/run/*.pickle
 src/run/done/*.pickle
 src/bin/ssh_host*
+# Emacs
+*~
+\#*\#
+

--- a/requirements_hub.txt
+++ b/requirements_hub.txt
@@ -27,3 +27,7 @@ xmltodict==0.11.0 # drugbank parsing
 beautifulsoup4==4.5.1 # drugbank dumper
 lxml # bs4 html parsing (note: no version avail to set it fixed)
 pandas==0.19.1 # sider parser
+aiocron
+IPython
+pympler
+

--- a/src/hub/dataload/sources/chebi/chebi_parser.py
+++ b/src/hub/dataload/sources/chebi/chebi_parser.py
@@ -79,7 +79,7 @@ def restructure_dict(dictionary):
     restr_dict['chebi'] = clean_up(restr_dict['chebi'])
     restr_dict = dict_sweep(restr_dict,vals=[None,".", "-", "", "NA", "none", " ", "Not Available",
         "unknown","null","None","NaN"])
-    restr_dict = value_convert_to_number(unlist(restr_dict),skipped_keys=["beilstein","pubmed","sabio_rk","gmelin_registry_numbers","molbase"])
+    restr_dict = value_convert_to_number(unlist(restr_dict),skipped_keys=["beilstein","pubmed","sabio_rk","gmelin_registry_numbers","molbase", "synonyms", "wikipedia"])
     return restr_dict
 
 def find_inchikey(doc, drugbank_col, chembl_col):

--- a/src/hub/dataload/sources/chebi/chebi_parser.py
+++ b/src/hub/dataload/sources/chebi/chebi_parser.py
@@ -89,8 +89,8 @@ def find_inchikey(doc, drugbank_col, chembl_col):
     if 'inchikey' in doc["chebi"]:
         _id = doc["chebi"]['inchikey']
     elif drugbank_col and chembl_col:
-        if 'drugbank' in doc["chebi"]:
-            d = drugbank_col.find_one({'_id':doc["chebi"]['drugbank']})
+        if 'xref' in doc['chebi'].keys() and 'drugbank' in doc["chebi"]['xref']:
+            d = drugbank_col.find_one({'_id':doc["chebi"]['xref']['drugbank']})
             if d != None:
                 try:
                     _id = d['drugbank']['inchi_key']

--- a/src/hub/dataload/sources/chebi/chebi_parser.py
+++ b/src/hub/dataload/sources/chebi/chebi_parser.py
@@ -29,12 +29,13 @@ def clean_up(_dict):
             value[0] = value[0].replace('</stereo>','').replace('</ital>','')
         # restructure the pubchem_database_links field
         if key == 'pubchem_database_links':
+            key = 'pubchem'
             new_pubchem_dict = {}
             if type(value) == list:
                 for _value in value:
                     splitted_results = _value.split(':')
                     if len(splitted_results) == 2:
-                        new_pubchem_dict[splitted_results[0]] = splitted_results[1][1:]
+                        new_pubchem_dict[splitted_results[0].lower()] = splitted_results[1][1:]
             value = new_pubchem_dict
         _temp[key] = value
     return _temp

--- a/src/hub/dataload/sources/chebi/chebi_parser.py
+++ b/src/hub/dataload/sources/chebi/chebi_parser.py
@@ -28,7 +28,7 @@ def clean_up(_dict):
             value[0] = value[0].replace('<stereo>','').replace('<ital>','')
             value[0] = value[0].replace('</stereo>','').replace('</ital>','')
         # restructure the pubchem_database_links field
-        if key == 'pubchem_database_links':
+        elif key == 'pubchem_database_links':
             key = 'pubchem'
             new_pubchem_dict = {}
             if type(value) == list:
@@ -37,6 +37,17 @@ def clean_up(_dict):
                     if len(splitted_results) == 2:
                         new_pubchem_dict[splitted_results[0].lower()] = splitted_results[1][1:]
             value = new_pubchem_dict
+        elif key == 'lincs_database_links':
+            key = 'lincs'
+        elif key == 'kegg_drug_database_links':
+            key = 'kegg_drug'
+        elif key == 'iupac_names':
+            key = 'iupac'
+        elif key == 'wikipedia_database_links':
+            key = 'wikipedia'
+            value = {'url_stub': value}
+        elif key == 'cas_registry_numbers':
+            key = 'cas'
         _temp[key] = value
     return _temp
 

--- a/src/hub/dataload/sources/chebi/chebi_parser.py
+++ b/src/hub/dataload/sources/chebi/chebi_parser.py
@@ -48,6 +48,16 @@ def clean_up(_dict):
             value = {'url_stub': value}
         elif key == 'cas_registry_numbers':
             key = 'cas'
+        elif key == 'chebi_id':
+            key = 'id'
+        elif key == 'chebi_name':
+            key = 'name'
+        elif key == 'drugbank_database_links':
+            key = 'drugbank'
+        elif key == 'pubmed_citation_links':
+            key = 'pubchem'
+        elif key == 'sabio_rk_database_links':
+            key = 'sabio_rk'
         _temp[key] = value
     return _temp
 
@@ -58,7 +68,7 @@ def restructure_dict(dictionary):
     restr_dict['chebi'] = clean_up(restr_dict['chebi'])
     restr_dict = dict_sweep(restr_dict,vals=[None,".", "-", "", "NA", "none", " ", "Not Available",
         "unknown","null","None","NaN"])
-    restr_dict = value_convert_to_number(unlist(restr_dict),skipped_keys=["beilstein_registry_numbers","pubmed_citation_links","sabio_rk_database_links","gmelin_registry_numbers","molbase_database_links"])
+    restr_dict = value_convert_to_number(unlist(restr_dict),skipped_keys=["beilstein_registry_numbers","pubmed","sabio_rk","gmelin_registry_numbers","molbase_database_links"])
     return restr_dict
 
 def find_inchikey(doc, drugbank_col, chembl_col):
@@ -68,8 +78,8 @@ def find_inchikey(doc, drugbank_col, chembl_col):
     if 'inchikey' in doc["chebi"]:
         _id = doc["chebi"]['inchikey']
     elif drugbank_col and chembl_col:
-        if 'drugbank_database_links' in doc["chebi"]:
-            d = drugbank_col.find_one({'_id':doc["chebi"]['drugbank_database_links']})
+        if 'drugbank' in doc["chebi"]:
+            d = drugbank_col.find_one({'_id':doc["chebi"]['drugbank']})
             if d != None:
                 try:
                     _id = d['drugbank']['inchi_key']
@@ -99,4 +109,3 @@ def find_inchikey(doc, drugbank_col, chembl_col):
                 else:
                     _id = doc['_id']
     return _id
-

--- a/src/hub/dataload/sources/chebi/chebi_parser.py
+++ b/src/hub/dataload/sources/chebi/chebi_parser.py
@@ -40,8 +40,6 @@ def clean_up(_dict):
             value = new_pubchem_dict
         elif key == 'iupac_names':
             key = 'iupac'
-        elif key == 'cas_registry_numbers':
-            key = 'cas'
         elif key == 'chebi_id':
             key = 'id'
         elif key == 'chebi_name':
@@ -51,8 +49,14 @@ def clean_up(_dict):
             key = 'wikipedia'
             value = {'url_stub': value}
             _xref[key] = value
+        elif key == 'beilstein_registry_numbers':
+            key = 'beilstein'
+            _xref[key] = value
         elif '_database_links' in key:
             key = key.replace('_database_links', '')
+            _xref[key] = value
+        elif '_registry_numbers' in key:
+            key = key.replace('_registry_numbers', '')
             _xref[key] = value
         elif '_citation_links' in key:
             key = key.replace('_citation_links', '')
@@ -75,7 +79,7 @@ def restructure_dict(dictionary):
     restr_dict['chebi'] = clean_up(restr_dict['chebi'])
     restr_dict = dict_sweep(restr_dict,vals=[None,".", "-", "", "NA", "none", " ", "Not Available",
         "unknown","null","None","NaN"])
-    restr_dict = value_convert_to_number(unlist(restr_dict),skipped_keys=["beilstein_registry_numbers","pubmed","sabio_rk","gmelin_registry_numbers","molbase"])
+    restr_dict = value_convert_to_number(unlist(restr_dict),skipped_keys=["beilstein","pubmed","sabio_rk","gmelin_registry_numbers","molbase"])
     return restr_dict
 
 def find_inchikey(doc, drugbank_col, chembl_col):

--- a/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
+++ b/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
@@ -127,19 +127,20 @@ def find_inchi_key(doc, drugbank_col, pubchem_col, chembl_col, chebi_col):
 
     if _flag:
         _flag = 0
-        if 'cross_references' in doc ["pharmgkb"]:
-            for key in doc["pharmgkb"]['cross_references']:
-                if key == 'pubchem_compound':
-                    cid = doc["pharmgkb"]['cross_references'].get(key)
-                    d = pubchem_col.find_one({'_id':cid})
-                    if d != None:
-                        try:
-                           _id = d['pubchem']['inchi_key']
-                        except KeyError:
-                            _id = d['_id']
+        if 'xref' in doc ["pharmgkb"]:
+            for key in doc["pharmgkb"]['xref']:
+                if key == 'pubchem':
+                    if 'cid' in doc['pharmgkb']['xref']['pubchem'].keys():
+                        cid = doc["pharmgkb"]['xref']['pubchem']['cid']
+                        d = pubchem_col.find_one({'_id':cid})
+                        if d != None:
+                            try:
+                                _id = d['pubchem']['inchi_key']
+                            except KeyError:
+                                _id = d['_id']
 
                 elif key=='drugbank':
-                    db_id = doc["pharmgkb"]['cross_references'].get(key)
+                    db_id = doc["pharmgkb"]['xref'].get(key)
                     d = drugbank_col.find_one({'_id':db_id})
                     if d != None:
                         try:
@@ -147,8 +148,8 @@ def find_inchi_key(doc, drugbank_col, pubchem_col, chembl_col, chebi_col):
                         except KeyError:
                             _id = d['_id']
                 elif key =='chebi':
-                    chebi = doc["pharmgkb"]['cross_references'].get(key)
-                    d = chebi_col.find_one({'_id':'CHEBI:'+chebi})
+                    chebi = doc["pharmgkb"]['xref'].get(key)
+                    d = chebi_col.find_one({'_id':chebi})
                     if d != None:
                         try:
                            _id = d['chebi']['inchikey']

--- a/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
+++ b/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
@@ -56,7 +56,7 @@ def restr_dict(d):
             k = key.lower().replace(" ","_").replace('-','_').replace(".","_")
             _d.update({k:val})
         elif key == "PharmGKB Accession Id":
-            k = key.lower().replace(" ","_").replace(".","_")
+            k = 'id'
             _d.update({k:val})
         elif key == "Cross-references":
             k = "xref"
@@ -82,12 +82,14 @@ def clean_up(d):
             for ele in val:
                 idx = ele.find(':')
                 # Note:  original pharmgkb keys do not have '.'
-                k = ele[0:idx].lower().replace(' ','_').replace('-','_')
+                k = transform_xref_fieldnames(ele[0:idx])
                 v = ele[idx+1:]
                 # Handle nested elements (ex: 'wikipedia.url_stub') here
                 sub_d = sub_field(k, v)
                 _d.update(sub_d)
     # 'xref' and 'external_vocabulary' are merged
+    if 'external_vocabulary' in d.keys():
+        d.pop('external_vocabulary')
     d.update({'xref':_d})
     return d
 
@@ -181,3 +183,17 @@ def remove_paren(v):
     if idx != -1:
         return v[0:idx]
     return v
+
+def transform_xref_fieldnames(k):
+    fields = [
+        ('Chemical Abstracts Service', 'cas'),
+        ('Therapeutic Targets Database', 'ttd'),
+        ('PubChem Substance', 'pubchem.sid'),
+        ('PubChem Compound', 'pubchem.cid')
+        ]
+    for orig_f, new_f in fields:
+        if orig_f in k:
+            k = k.replace(orig_f, new_f)
+            break
+    k = k.lower().replace(' ','_').replace('-','_')
+    return k

--- a/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
+++ b/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
@@ -39,9 +39,9 @@ def restr_dict(d):
                     v = v.replace('Web Resource', 'wikipedia.url_stub')
                     v = v.replace('http://en.wikipedia.org/wiki/', '')
             # Add 'CHEBI:' prefix if not there already
-            elif re.match('^ChEBI:', v):
-                if not re.match('^ChEBI:CHEBI', v):
-                    v = re.sub('^ChEBI:', 'ChEBI:CHEBI:', v)
+            elif 'ChEBI:' in v:
+                if 'ChEBI:CHEBI' not in v:
+                    v = v.replace('ChEBI:', 'ChEBI:CHEBI:')
             res.append(v)
         return res
     _d = {}
@@ -67,7 +67,10 @@ def restr_dict(d):
         elif key == "External Vocabulary":
             # external_vocabulary - remove parenthesis and text within
             k = "external_vocabulary"
-            val = re.sub('\([^)]*\)', '', val)
+            # note:  regular expressions appear to be causing an error
+            # val = re.sub('\([^)]*\)', '', val)
+            val = val.split(',"')
+            val = list(map(lambda each:remove_paren(each.strip('"')), val))  #python 3 compatible
             _d.update({k:val})
     return _d
 
@@ -170,3 +173,10 @@ def sub_field(k, v):
         field_d = field_d[f]
     field_d[fields[-1]] = v
     return res
+
+def remove_paren(v):
+    """remove first occurance of trailing parentheses from a string"""
+    idx = v.find('(')
+    if idx != -1:
+        return v[0:idx]
+    return v

--- a/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
+++ b/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
@@ -76,9 +76,9 @@ def restr_dict(d):
 
 def clean_up(d):
     _li = ['xref','external_vocabulary']
+    _d= {}
     for key, val in iter(d.items()):
         if key in _li:
-            _d= {}
             for ele in val:
                 idx = ele.find(':')
                 # Note:  original pharmgkb keys do not have '.'
@@ -87,7 +87,8 @@ def clean_up(d):
                 # Handle nested elements (ex: 'wikipedia.url_stub') here
                 sub_d = sub_field(k, v)
                 _d.update(sub_d)
-            d.update({key:_d})
+    # 'xref' and 'external_vocabulary' are merged
+    d.update({'xref':_d})
     return d
 
 def find_inchi_key(doc, drugbank_col, pubchem_col, chembl_col, chebi_col):


### PR DESCRIPTION
Refactor the 'pharmgkb' and 'chebi' parsers.  Several fields have been shorted and rearranged.  An analysis of all renamed fields was done to check that renamed fields contains data.  Also, an analysis of keys was done before and after the the refactor checking that all _id fields are unchanged.
