### PR TITLE
globally change field name from 'xref' to 'xrefs'

### DIFF
--- a/src/hub/dataload/sources/chebi/chebi_parser.py
+++ b/src/hub/dataload/sources/chebi/chebi_parser.py
@@ -19,7 +19,7 @@ def load_data(sdf_file):# drugbank_col=None, chembl_col=None):
 
 def clean_up(_dict):
     _temp = dict()
-    _xref = dict()
+    _xrefs = dict()
     _citation = dict()
     for key, value in iter(_dict.items()):
         key = key.lower().replace(' ','_').replace('-','_')
@@ -46,16 +46,16 @@ def clean_up(_dict):
         if key == 'wikipedia_database_links':
             key = 'wikipedia'
             value = {'url_stub': value}
-            _xref[key] = value
+            _xrefs[key] = value
         elif key == 'beilstein_registry_numbers':
             key = 'beilstein'
-            _xref[key] = value
+            _xrefs[key] = value
         elif '_database_links' in key:
             key = key.replace('_database_links', '')
-            _xref[key] = value
+            _xrefs[key] = value
         elif '_registry_numbers' in key:
             key = key.replace('_registry_numbers', '')
-            _xref[key] = value
+            _xrefs[key] = value
         elif '_citation_links' in key:
             key = key.replace('_citation_links', '')
             if key == 'pubmed_central':
@@ -64,8 +64,8 @@ def clean_up(_dict):
         else:
             _temp[key] = value
 
-    if _xref.keys():
-        _temp['xref'] = _xref
+    if _xrefs.keys():
+        _temp['xrefs'] = _xrefs
     if _citation.keys():
         _temp['citation'] = _citation
     return _temp

--- a/src/hub/dataload/sources/chebi/chebi_upload.py
+++ b/src/hub/dataload/sources/chebi/chebi_upload.py
@@ -27,7 +27,7 @@ class ChebiUploader(BaseDrugUploader):
     keylookup = MyChemKeyLookup(
             [('inchikey','chebi.inchikey'),
              ('chebi','chebi.id'),
-             ('drugbank','chebi.xref.drugbank'),
+             ('drugbank','chebi.xrefs.drugbank'),
              ],
             copy_from_doc=True)
 
@@ -87,7 +87,7 @@ class ChebiUploader(BaseDrugUploader):
                         "inn": {
                             "type": "text"
                             },
-                        "xref": {
+                        "xrefs": {
                             "properties": {
                                 "molbase": {
                                     "normalizer": "keyword_lowercase_normalizer",

--- a/src/hub/dataload/sources/chembl/chembl_parser.py
+++ b/src/hub/dataload/sources/chembl/chembl_parser.py
@@ -24,6 +24,7 @@ def restructure_xref(xref_list):
     """
     xref_output = defaultdict(list)
     for _record in xref_list:
+        # note that the 'xref' field names are from the chembl datasource, not the parser
         if 'xref_src' in _record and _record['xref_src'] == 'PubChem':
             assert _record['xref_name'].startswith('SID: ')
             xref_output['pubchem'].append({'sid': int(_record['xref_id'])})
@@ -59,7 +60,7 @@ def restructure_dict(dictionary):
     if _flag == 0:
         restr_dict['chembl'] = dictionary
     if 'cross_references' in restr_dict['chembl'] and restr_dict['chembl']['cross_references']:
-        restr_dict['chembl']['xref'] = restructure_xref(restr_dict['chembl']['cross_references'])
+        restr_dict['chembl']['xrefs'] = restructure_xref(restr_dict['chembl']['cross_references'])
 
     del restr_dict['chembl']['molecule_structures']
     del restr_dict['chembl']['cross_references']

--- a/src/hub/dataload/sources/chembl/chembl_upload.py
+++ b/src/hub/dataload/sources/chembl/chembl_upload.py
@@ -261,7 +261,7 @@ class ChemblUploader(BaseDrugUploader,ParallelizedSourceUploader):
                         "oral": {
                                 "type": "boolean"
                                 },
-                        "xref": {
+                        "xrefs": {
                                 "properties": {
                                     "drugcentral": {
                                         "properties": {

--- a/src/hub/dataload/sources/drugbank/drugbank_mapping.py
+++ b/src/hub/dataload/sources/drugbank/drugbank_mapping.py
@@ -574,7 +574,7 @@ drugbank_mapping = {
                         }
                     }
                 },
-                "xref": {
+                "xrefs": {
                     "properties": {
                         "ahfs_codes": {
                             "normalizer": "keyword_lowercase_normalizer",

--- a/src/hub/dataload/sources/drugbank/drugbank_parser.py
+++ b/src/hub/dataload/sources/drugbank/drugbank_parser.py
@@ -60,8 +60,8 @@ def restructure_dict(dictionary):
     carriers_list = []
     transporters_list = []
     atccode_list = []
-    xref_dict = {}
-    xref_pubchem_dict = {}
+    xrefs_dict = {}
+    xrefs_pubchem_dict = {}
 
     for key,value in iter(dictionary.items()):
         if key == 'name' and value:
@@ -256,7 +256,7 @@ def restructure_dict(dictionary):
         elif key == 'ahfs-codes' and value:
             for x in value:
                 key = key.replace('-','_')
-                xref_dict.update({key:value[x]})
+                xrefs_dict.update({key:value[x]})
 
         elif key == 'food-interactions' and value:
             food_interaction_list = []
@@ -362,29 +362,29 @@ def restructure_dict(dictionary):
                 for x in ele:
                     if x == 'resource':
                         if ele[x] == "Drugs Product Database (DPD)":
-                            xref_dict['dpd'] = ele['identifier']
+                            xrefs_dict['dpd'] = ele['identifier']
                         elif ele[x] == "KEGG Drug":
                             kegg_dict['did'] = ele['identifier']
-                            xref_dict['kegg'] = kegg_dict
+                            xrefs_dict['kegg'] = kegg_dict
                         elif ele[x] == "KEGG Compound":
                             kegg_dict['cid'] = ele['identifier']
-                            xref_dict['kegg'] = kegg_dict
+                            xrefs_dict['kegg'] = kegg_dict
                         elif ele[x] == "PharmGKB":
-                            xref_dict['pharmgkb'] = ele['identifier']
+                            xrefs_dict['pharmgkb'] = ele['identifier']
                         elif ele[x] == "Wikipedia":
                             wiki_dict = {'url_stub': ele['identifier']}
-                            xref_dict['wikipedia'] = wiki_dict
+                            xrefs_dict['wikipedia'] = wiki_dict
                         elif ele[x] == "ChemSpider":
-                            xref_dict['chemspider'] = ele['identifier']
+                            xrefs_dict['chemspider'] = ele['identifier']
                         elif ele[x] == "ChEBI":
-                            xref_dict['chebi'] = 'CHEBI:' + str(ele['identifier'])
+                            xrefs_dict['chebi'] = 'CHEBI:' + str(ele['identifier'])
                         elif ele[x] == "PubChem Compound":
-                            xref_pubchem_dict['cid'] = ele['identifier']
+                            xrefs_pubchem_dict['cid'] = ele['identifier']
                         elif ele[x] == "PubChem Substance":
-                            xref_pubchem_dict['sid'] = ele['identifier']
+                            xrefs_pubchem_dict['sid'] = ele['identifier']
                         else:
                             source = ele[x].lower().replace('-','_').replace(' ','_')
-                            xref_dict[source] = ele['identifier']
+                            xrefs_dict[source] = ele['identifier']
 
         elif key == 'external-links' and value:
             if isinstance(value['external-link'],list):
@@ -392,7 +392,7 @@ def restructure_dict(dictionary):
                     for x in ele:
                         try:
                             resource = ele['resource']
-                            xref_dict[resource.lower().replace('.','_')] = ele['url']
+                            xrefs_dict[resource.lower().replace('.','_')] = ele['url']
                         except:
                             pass
             else:
@@ -504,7 +504,7 @@ def restructure_dict(dictionary):
                 restr_atccode_dict(value['atc-code'])
 
 
-    xref_dict['atc_codes'] = atccode_list
+    xrefs_dict['atc_codes'] = atccode_list
     d1['targets'] = targets_list
     d1['carriers'] = carriers_list
     d1['enzymes'] = enzymes_list
@@ -512,9 +512,9 @@ def restructure_dict(dictionary):
     d1['predicted_properties'] = pred_properties_dict
     d1['experimental_properties'] = exp_prop_dict
     d1['products'] = products_list
-    if xref_pubchem_dict:
-        xref_dict['pubchem'] = xref_pubchem_dict
-    d1['xref'] = xref_dict
+    if xrefs_pubchem_dict:
+        xrefs_dict['pubchem'] = xrefs_pubchem_dict
+    d1['xrefs'] = xrefs_dict
     restr_dict['drugbank'] = d1
     restr_dict = unlist(restr_dict, [
         "drugbank.accession_number",
@@ -543,8 +543,8 @@ def restructure_dict(dictionary):
                                  "drugbank.predicted_properties.h_bond_acceptor_count",
                                  "drugbank.predicted_properties.h_bond_donor_count",
                                  "drugbank.predicted_properties.number_of_rings",
-                                 "drugbank.xref.guide_to_pharmacology",
-                                 "drugbank.xref.iuphar"])
+                                 "drugbank.xrefs.guide_to_pharmacology",
+                                 "drugbank.xrefs.iuphar"])
     # 'float' types
     restr_dict = float_convert(restr_dict,
                                include_keys=[

--- a/src/hub/dataload/sources/drugcentral/drugcentral_parser.py
+++ b/src/hub/dataload/sources/drugcentral/drugcentral_parser.py
@@ -150,15 +150,15 @@ def to_list(_key):
     else:
         return _key
 
-def xref_2_inchikey(xref_dict):
-    xref_key_list = ['unii', 'drugbank_id', 'chembl_id', 'chebi', 'pubchem_cid']
+def xrefs_2_inchikey(xrefs_dict):
+    xrefs_key_list = ['unii', 'drugbank_id', 'chembl_id', 'chebi', 'pubchem_cid']
     mychem_filed_dict = {'unii': 'unii.unii:', 'chebi': 'chebi.chebi_id:"', 'pubchem_cid': 'pubchem.cid:"CID','chembl_id': 'chembl.molecule_chembl_id:"', 'drugbank_id': 'drugbank.accession_number:"'}
     mychem_query = 'http://mychem.info/v1/query?q='
     result = None
-    for _key in xref_key_list:
-        if _key in xref_dict:
-            for _xref in to_list(xref_dict[_key]):
-                query_url = mychem_query + mychem_filed_dict[_key] + _xref + '"'
+    for _key in xrefs_key_list:
+        if _key in xrefs_dict:
+            for _xrefs in to_list(xrefs_dict[_key]):
+                query_url = mychem_query + mychem_filed_dict[_key] + _xrefs + '"'
                 json_doc = requests.get(query_url).json()
                 if 'hits' in json_doc and json_doc['hits']:
                     if len(json_doc['hits']) == 1:
@@ -191,11 +191,11 @@ def load_data():
                     "drug_dosage": drug_dosage.get(struc_id, {}),
                     "synonyms": synonyms.get(struc_id, {}),
                     "structures": structures.get(struc_id, {}),
-                    "xref": identifiers.get(struc_id, {})
+                    "xrefs": identifiers.get(struc_id, {})
                 }
             }
         else:
-            _id = xref_2_inchikey(identifiers.get(struc_id, {}))
+            _id = xrefs_2_inchikey(identifiers.get(struc_id, {}))
             if not _id:
                 _id = 'DrugCentral:' + str(struc_id)
             _doc = {
@@ -209,7 +209,7 @@ def load_data():
                     "drug_dosage": drug_dosage.get(struc_id, {}),
                     "synonyms": synonyms.get(struc_id, {}),
                     "structures": structures.get(struc_id, {}),
-                    "xref": identifiers.get(struc_id, {})
+                    "xrefs": identifiers.get(struc_id, {})
                 }
             }
         _doc = (dict_sweep(unlist(_doc), [None]))

--- a/src/hub/dataload/sources/drugcentral/drugcentral_upload.py
+++ b/src/hub/dataload/sources/drugcentral/drugcentral_upload.py
@@ -355,7 +355,7 @@ class DrugCentralUploader(uploader.DummySourceUploader):
                             "type": "text",
                             'copy_to': ['all'],
                             },
-                    "xref": {
+                    "xrefs": {
                             "properties": {
                                 "pubchem_cid": {
                                     "normalizer": "keyword_lowercase_normalizer",

--- a/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
+++ b/src/hub/dataload/sources/pharmgkb/pharmgkb_parser.py
@@ -19,8 +19,8 @@ def load_data(tsv_file):
         yield _dict
 
 def restr_dict(d):
-    def _restr_xref(xref):
-        """Restructure field names related to the pharmgkb.xref field"""
+    def _restr_xrefs(xrefs):
+        """Restructure field names related to the pharmgkb.xrefs field"""
         # Rename fields
         rename_fields = [
             ('National Drug Code Directory', 'ndc'),
@@ -28,7 +28,7 @@ def restr_dict(d):
             ('FDA Drug Label at DailyMed', 'dailymed.setid'),
             ]
         res = []
-        for v in xref:
+        for v in xrefs:
             for rf_orig, rf_new in rename_fields:
                 if rf_orig in v:
                     v = v.replace(rf_orig, rf_new)
@@ -58,10 +58,10 @@ def restr_dict(d):
             k = 'id'
             _d.update({k:val})
         elif key == "Cross-references":
-            k = "xref"
+            k = "xrefs"
             val = val.split(',"')
             val = list(map(lambda each:each.strip('"'), val))  #python 3 compatible
-            val = _restr_xref(val)
+            val = _restr_xrefs(val)
             _d.update({k:val})
         elif key == "External Vocabulary":
             # external_vocabulary - remove parenthesis and text within
@@ -74,24 +74,24 @@ def restr_dict(d):
     return _d
 
 def clean_up(d):
-    _li = ['xref','external_vocabulary']
+    _li = ['xrefs','external_vocabulary']
     _d= {}
     for key, val in iter(d.items()):
         if key in _li:
             for ele in val:
                 idx = ele.find(':')
                 # Note:  original pharmgkb keys do not have '.'
-                k = transform_xref_fieldnames(ele[0:idx])
+                k = transform_xrefs_fieldnames(ele[0:idx])
                 v = ele[idx+1:]
                 if k in ["pubchem.cid","pubchem.sid"]:
                     v = int(v)
                 # Handle nested elements (ex: 'wikipedia.url_stub') here
                 sub_d = sub_field(k, v)
                 _d.update(sub_d)
-    # 'xref' and 'external_vocabulary' are merged
+    # 'xrefs' and 'external_vocabulary' are merged
     if 'external_vocabulary' in d.keys():
         d.pop('external_vocabulary')
-    d.update({'xref':_d})
+    d.update({'xrefs':_d})
     return d
 
 def sub_field(k, v):
@@ -112,7 +112,7 @@ def remove_paren(v):
         return v[0:idx]
     return v
 
-def transform_xref_fieldnames(k):
+def transform_xrefs_fieldnames(k):
     fields = [
         ('Chemical Abstracts Service', 'cas'),
         ('Therapeutic Targets Database', 'ttd'),

--- a/src/hub/dataload/sources/pharmgkb/pharmgkb_upload.py
+++ b/src/hub/dataload/sources/pharmgkb/pharmgkb_upload.py
@@ -25,9 +25,9 @@ class PharmGkbUploader(BaseDrugUploader):
     __metadata__ = {"src_meta" : SRC_META}
     keylookup = MyChemKeyLookup(
             [('inchi', 'pharmgkb.inchi'),
-             ('pubchem', 'pharmgkb.xref.pubchem.cid'),
-             ('drugbank', 'pharmgkb.xref.drugbank'),
-             ('chebi', 'pharmgkb.xref.chebi')])
+             ('pubchem', 'pharmgkb.xrefs.pubchem.cid'),
+             ('drugbank', 'pharmgkb.xrefs.drugbank'),
+             ('chebi', 'pharmgkb.xrefs.chebi')])
 
     def load_data(self,data_folder):
         self.logger.info("Load data from '%s'" % data_folder)
@@ -74,7 +74,7 @@ class PharmGkbUploader(BaseDrugUploader):
                         "type": {
                             "type": "text"
                             },
-                        "xref": {
+                        "xrefs": {
                             "properties": {
                                 "web_resource": {
                                     "normalizer": "keyword_lowercase_normalizer",

--- a/src/hub/datatransform/keylookup.py
+++ b/src/hub/datatransform/keylookup.py
@@ -35,7 +35,7 @@ graph_mychem.add_edge('pubchem', 'inchikey',
                       object=MongoDBEdge('pubchem', 'pubchem.cid', 'pubchem.inchi_key'))
 
 graph_mychem.add_edge('pharmgkb', 'drugbank',
-                      object=MongoDBEdge('pharmgkb', 'pharmgkb.id', 'pharmgkb.xref.drugbank'))
+                      object=MongoDBEdge('pharmgkb', 'pharmgkb.id', 'pharmgkb.xrefs.drugbank'))
 
 # self-loops to check looked-up values exist in official collection
 graph_mychem.add_edge('drugbank', 'drugbank',


### PR DESCRIPTION
Globally change collection field names from 'xref' to 'xrefs'.  These changes were done using a global find and replace.  The 'ginas' parser which already uses the 'xrefs' field name was excluded from this process.  Following the changes, all changed data sources except for 'drugcentral' were manually tested through the upload step and the field name change was verified.
