### PR TITLE
issue_005 - parse target gene_name and pmids

### DIFF
--- a/src/hub/dataload/sources/drugbank/drugbank_parser.py
+++ b/src/hub/dataload/sources/drugbank/drugbank_parser.py
@@ -37,7 +37,7 @@ def restr_protein_dict(dictionary):
             x = x.replace('-','_')
             _dict.update({x:dictionary['known-action']})
         elif x == 'polypeptide':
-            _li2 = ['general-function','specific-function']
+            _li2 = ['general-function','specific-function', 'gene-name']
             for i in y:
                 if i ==  "@id":
                     _dict.update({'uniprot':y[i]})
@@ -46,6 +46,19 @@ def restr_protein_dict(dictionary):
                 elif i in _li2:
                     j = i.replace('-','_')
                     _dict.update({j:y[i]})
+        elif x == 'references' and y:
+            # extract a list of pubmed-ids
+            pubmed_lst = []
+            try:
+                articles = y['articles']['article']
+            except (KeyError, TypeError):
+                articles = []
+            if isinstance(articles, list):
+                for article in articles:
+                    pubmed_lst.append(article['pubmed-id'])
+            else:
+                pubmed_lst.append(articles['pubmed-id'])
+            _dict.update({'pmids':pubmed_lst})
     return _dict
 
 def restructure_dict(dictionary):


### PR DESCRIPTION
See MyChem.Info Issue #5 .  This patch returns gene_name and pmids for each target.  It has been tested on the drugbank input data file.  The same number of records was returned before and after the patch.

A report (using the biothings.api hub) for the change was run:

Summary
-------
Added documents: 0
Deleted documents: 0
Updated documents: 7547