### PR TITLE
Fix of Issue#67

### DIFF
--- a/docs/doc/data_source.rst
+++ b/docs/doc/data_source.rst
@@ -29,8 +29,21 @@ The value of each fields above is a list. In some cases, the list can be very la
 
 This truncation affects only 143 objects (as of 2018-11-28, `full list here <https://github.com/biothings/mychem.info/blob/master/src/hub/dataload/sources/chebi/exclusion_ids.py>`_), comparing to total 98,511 objects containing `chebi` data (<0.15%).
 
-.. ChEMBL
-.. ------
+ChEMBL
+------
+
+Data for `ChEMBL <https://www.ebi.ac.uk/chemb>`_ is pulled from 6 online json sources:
+
+- `Molecule <https://www.ebi.ac.uk/chembl/api/data/molecule.json>`_, which serves as a root data source. Entries from other sources are attached molecule entries as new fields
+- `Drug Indications <https://www.ebi.ac.uk/chembl/api/data/drug_indication.json>`_, which will parsed and attached to molecule entries, e.g. ``molecule["drug_indications"] = list_of_drug_indications``
+- `Drug Mechanisms <https://www.ebi.ac.uk/chembl/api/data/mechanism.json>`_, which will parsed and attached to molecule entries, e.g. ``molecule["drug_mechanism"] = list_of_drug_mechanism``
+- `Drug <https://www.ebi.ac.uk/chembl/api/data/drug.json>`_, used to augment ``first_approval`` field to drug indication entries
+- `Target <https://www.ebi.ac.uk/chembl/api/data/target.json>`_, used to augment ``target_name`` and ``target_organism`` fields to drug mechanism entries
+- `Binding Sites <https://www.ebi.ac.uk/chembl/api/data/binding_site.json>`_, used to augment ``binding_site_name`` field to drug mechanism entries
+
+Dictionaries are created for each chemical based on their ``standardinchikey`` in the following format: 
+
+``{_id: "standardinchikey", "chembl": {"<drug_indications>":"<...>", "<drug_mechanisms>":"<...>",..}}``
 
 DrugBank
 --------

--- a/src/hub/dataload/sources/chembl/chembl_dump.py
+++ b/src/hub/dataload/sources/chembl/chembl_dump.py
@@ -47,7 +47,7 @@ class ChemblDumper(HTTPDumper):
         # Used to join with `mechanism` by `target_chembl_id`
         "target": "https://www.ebi.ac.uk/chembl/api/data/target.json",
         # used to join with `mechanism` by `site_id`
-        "binding_sites": "https://www.ebi.ac.uk/chembl/api/data/binding_site.json"
+        "binding_site": "https://www.ebi.ac.uk/chembl/api/data/binding_site.json"
     }
 
     SCHEDULE = "0 12 * * *"
@@ -110,7 +110,6 @@ class ChemblDumper(HTTPDumper):
             return True
 
         local_data = self.load_json_from_file(localfile)
-
         self.logger.info("ChEMBL DB version: remote=={}, local=={}".
                          format(remote_data["chembl_db_version"], local_data["chembl_db_version"]))
 
@@ -131,6 +130,9 @@ class ChemblDumper(HTTPDumper):
             current_localfile = None
 
         remote_better = self.remote_is_better(self.__class__.SRC_VERSION_URL, current_localfile)
+        self.logger.info("ChEMBL Dump: force=={}, current_localfile=={}, remote_better=={}".
+                         format(force, current_localfile, remote_better))
+
         if force or current_localfile is None or remote_better:
             new_localfile = os.path.join(self.new_data_folder, version_filename)
             self.to_dump.append({"remote": self.__class__.SRC_VERSION_URL, "local": new_localfile})

--- a/src/hub/dataload/sources/chembl/chembl_dump.py
+++ b/src/hub/dataload/sources/chembl/chembl_dump.py
@@ -1,11 +1,12 @@
-import os
-import os.path
-import sys
-import time
 import glob
 import json
+import os
+import os.path
+import itertools
 
-import biothings, config
+import biothings
+import config
+
 biothings.config_for_app(config)
 
 from config import DATA_ARCHIVE_ROOT
@@ -17,67 +18,185 @@ class ChemblDumper(HTTPDumper):
 
     SRC_NAME = "chembl"
     SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
-    SRC_DATA_URL = "https://www.ebi.ac.uk/chembl/api/data/molecule.json"
+
     SRC_VERSION_URL = "https://www.ebi.ac.uk/chembl/api/data/status.json"
 
-    SCHEDULE = "0 12 * * *"
-    CHUNK_MERGE_SIZE = 100 # number of part files merged together after download
+    """
+    As the code is written, we have: 
+            
+    - 1,961,462 "molecule" json objects
+    - 5,134 "mechanism" json objects
+    - 37,259 "drug_indication" json objects
+    - 13,308 "drug" json objects
+    - 13,382 "target" json objects
+    - 14,342 "binding_site" json objects
+    """
+    SRC_DATA_URLS = {
+        # primary data source
+        "molecule": "https://www.ebi.ac.uk/chembl/api/data/molecule.json",
 
-    def remote_is_better(self,remotefile,localfile):
-        remote_data = json.loads(self.client.get(self.__class__.SRC_VERSION_URL).text)
+        # supplementary data sources to `molecule`
+        "drug_indication": "https://www.ebi.ac.uk/chembl/api/data/drug_indication.json",
+        "mechanism": "https://www.ebi.ac.uk/chembl/api/data/mechanism.json",
+
+        # Used to augment `first_approval` field to `drug_indication`
+        # E.g. if a drug has `first_approval` of 1990, all its drug indications will have a `first_approval`
+        #   field of 1990
+        "drug": "https://www.ebi.ac.uk/chembl/api/data/drug.json",
+
+        # Used to join with `mechanism` by `target_chembl_id`
+        "target": "https://www.ebi.ac.uk/chembl/api/data/target.json",
+        # used to join with `mechanism` by `site_id`
+        "binding_sites": "https://www.ebi.ac.uk/chembl/api/data/binding_site.json"
+    }
+
+    SCHEDULE = "0 12 * * *"
+
+    # number of documents in each download job, i.e. number of documents in each .part* file
+    TO_DUMP_DOWNLOAD_SIZE = 1000
+    # number of .part* files to be merged together after download
+    POST_DUMP_MERGE_SIZE = 100
+
+    def get_total_count_of_documents(self, src_data_name):
+        """
+        Get the total count of documents from the first page of the url specified by `src_data_name`.
+        `total_count` is a member of the `page_meta` member of the root json object.
+
+        Args:
+            src_data_name (str): must be a key to self.__class__.SRC_DATA_URLS
+
+        Returns:
+            int: the total count of documents
+        """
+        if src_data_name not in self.__class__.SRC_DATA_URLS:
+            raise KeyError("Cannot recognize src_data_name={}. Must be one of {{{}}}".
+                           format(src_data_name, ", ".join(self.__class__.SRC_DATA_URLS.keys())))
+
+        data = self.load_json_from_file(self.__class__.SRC_DATA_URLS[src_data_name])
+        return data["page_meta"]["total_count"]
+    
+    def load_json_from_file(self, file) -> dict:
+        """
+        Read the content of `file` and return the json object
+
+        Args:
+            file (str): could either be an URL ("remotefile") or a path to a local text file ("localfile") 
+
+        Returns:
+            object: the json object read from the `file`
+        """
+
+        """
+        Note that:
+        
+        - `json.loads(string)` deserializes string
+        - `json.load(file)` deserializes a file object
+        """
+        if file.startswith("http://") or file.startswith("https://"):  # file is an URL
+            data = json.loads(self.client.get(file).text)
+        else:  # file is a local path
+            data = json.load(open(file))
+
+        return data
+
+    def remote_is_better(self, remotefile, localfile):
+        remote_data = self.load_json_from_file(remotefile)
         assert "chembl_db_version" in remote_data
-        assert remote_data["status"] == "UP" # API is working correctly
+        assert remote_data["status"] == "UP"  # API is working correctly
         self.release = remote_data["chembl_db_version"]
-        # get the total count from the first page
-        data = json.loads(self.client.get(self.__class__.SRC_DATA_URL).text)
-        self.total_count = data["page_meta"]["total_count"]
+
         if localfile is None:
             # ok we have the release, we can't compare further so we need to download
             return True
-        local_data = json.load(open(localfile))
+
+        local_data = self.load_json_from_file(localfile)
+
+        self.logger.info("ChEMBL DB version: remote=={}, local=={}".
+                         format(remote_data["chembl_db_version"], local_data["chembl_db_version"]))
+
         # comparing strings should work since it's formatted as "ChEMBL_xxx"
         if remote_data["chembl_db_version"] > local_data["chembl_db_version"]:
             return True
         else:
             return False
 
-    def create_todump_list(self, force=False):
+    def create_todump_list(self, force=False, **kwargs):
         version_filename = os.path.basename(self.__class__.SRC_VERSION_URL)
         try:
-            current_localfile = os.path.join(self.current_data_folder,version_filename)
+            current_localfile = os.path.join(self.current_data_folder, version_filename)
             if not os.path.exists(current_localfile):
                 current_localfile = None
         except TypeError:
             # current data folder doesn't even exist
             current_localfile = None
-        remote_better = self.remote_is_better(self.__class__.SRC_VERSION_URL,current_localfile)
+
+        remote_better = self.remote_is_better(self.__class__.SRC_VERSION_URL, current_localfile)
         if force or current_localfile is None or remote_better:
-            new_localfile = os.path.join(self.new_data_folder,version_filename)
-            self.to_dump.append({"remote":self.__class__.SRC_VERSION_URL, "local":new_localfile})
-            # now we need to scroll the API endpoint. Let's get the total number of records
-            # and generate URLs for each call to parallelize the downloads
-            for num,i in enumerate(range(0,self.total_count,1000)):
-                remote = self.__class__.SRC_DATA_URL + "?limit=1000&offset=" + str(i)
-                local = os.path.join(self.new_data_folder,"molecule.part%d" % num)
-                self.to_dump.append({"remote":remote, "local":local})
+            new_localfile = os.path.join(self.new_data_folder, version_filename)
+            self.to_dump.append({"remote": self.__class__.SRC_VERSION_URL, "local": new_localfile})
+
+            """
+            Now we need to scroll the API endpoints. Let's get the total number of records
+            and generate URLs for each call to parallelize the downloads for each type of source data, 
+            i.e. "molecule", "mechanism", "drug_indication", "drug", "target" and "binding_site".
+            
+            The partition size is set to 1000 json objects (represented by `TO_DUMP_DOWNLOAD_SIZE`). 
+            
+            E.g. suppose for "molecule" data we have a `total_count` of 2500 json objects, and then we'll have, 
+            in the process of iteration:
+            
+            - (part_index, part_start) = (0, 0)
+            - (part_index, part_start) = (1, 1000)
+            - (part_index, part_start) = (2, 2000)
+            
+            Therefore we would download 3 files, i.e. "molecule.part0", "molecule.part1", and "molecule.part2". 
+            """
+            part_size = self.__class__.TO_DUMP_DOWNLOAD_SIZE
+            for src_data_name in self.__class__.SRC_DATA_URLS:
+                total_count = self.get_total_count_of_documents(src_data_name)
+                for part_index, part_start in enumerate(range(0, total_count, part_size)):
+                    remote = self.__class__.SRC_DATA_URLS[src_data_name] + \
+                             "?limit=" + str(part_size) + \
+                             "&offset=" + str(part_start)
+                    local = os.path.join(self.new_data_folder, "{}.part{}".format(src_data_name, part_index))
+                    self.to_dump.append({"remote": remote, "local": local})
 
     def post_dump(self, *args, **kwargs):
-        self.logger.info("Merging JSON documents in '%s'" % self.new_data_folder)
-        # we'll merge 100 files together, that's 100'000 documents. That way we don't have one huge
-        # big files and we don't have thousands of them too. We'll also remove metadata (useless now)
-        parts = glob.iglob(os.path.join(self.new_data_folder,"molecule.part*"))
-        for chunk,cnt in iter_n(parts,self.__class__.CHUNK_MERGE_SIZE,with_cnt=True):
-            outfile = os.path.join(self.new_data_folder,"molecule.%s.json" % cnt)
-            merged_data = {"molecules" : []}
-            for f in chunk:
-                data = json.load(open(f))
-                merged_data["molecules"].extend(data["molecules"])
-            json.dump(merged_data,open(outfile,"w"))
-            self.logger.info("Merged %s files" % cnt)
-        # now we can delete the parts
-        self.logger.info("Deleting part files")
-        parts = glob.iglob(os.path.join(self.new_data_folder,"molecule.part*"))
-        for f in parts:
-            os.remove(f)
-        self.logger.info("Post-dump merge done")
+        """
+        In the post-dump phase, for each type of source data, we merge each chunk of 100 .part* files
+        into one .*.json file. (This way we won't have a small number of huge files nor a pile of small files.)
 
+        E.g. as the code is written, we have 1,961,462 "molecule" json objects.
+        Therefore we would download 1,962 files, i.e. "molecule.part0", ..., "molecule.part1961".
+        For each chunk of 100 such files, e.g. "molecule.part0", ..., "molecule.part99", we merge them into one
+        json file, e.g. "molecule.100.json".
+
+        We'll also remove metadata (useless now)
+        """
+        self.logger.info("Merging JSON documents in '%s'" % self.new_data_folder)
+
+        chunk_size = self.__class__.POST_DUMP_MERGE_SIZE
+        for src_data_name in self.__class__.SRC_DATA_URLS:
+            part_files = glob.iglob(os.path.join(self.new_data_folder, "{}.part*".format(src_data_name)))
+            for chunk, cnt in iter_n(part_files, chunk_size, with_cnt=True):
+                outfile = os.path.join(self.new_data_folder, "{}.{}.json".format(src_data_name, cnt))
+
+                """
+                For each "molecule" json object, we only fetch the value associated with the "molecules" key.
+                This rule also applies to "mechanism", "drug_indication", "drug", "target" and "binding_site" 
+                json objects.
+                """
+                data_key = src_data_name + "s"
+                merged_value = itertools.chain.from_iterable(self.load_json_from_file(f)[data_key] for f in chunk)
+                merged_data = {data_key: list(merged_value)}
+
+                json.dump(merged_data, open(outfile, "w"))
+                self.logger.info("Merged %s %s files" % (src_data_name, cnt))
+
+            # now we can delete the part files
+            self.logger.info("Deleting part files")
+            part_files = glob.iglob(os.path.join(self.new_data_folder, "{}.part*".format(src_data_name)))
+            for f in part_files:
+                os.remove(f)
+
+        self.logger.info("Post-dump merge done")

--- a/src/hub/dataload/sources/chembl/chembl_parser.py
+++ b/src/hub/dataload/sources/chembl/chembl_parser.py
@@ -1,80 +1,680 @@
-import urllib.request
 import json
+import glob
+import urllib.parse
+from abc import ABC, abstractmethod
+from itertools import chain, groupby
 from collections import defaultdict
+
 from biothings.utils.dataload import dict_sweep, unlist, value_convert_to_number
 from biothings.utils.dataload import boolean_convert
 
-def load_data(input_file):
-    molecules_list = []
-    data = json.load(open(input_file))
-    molecules_list = data['molecules']
-    for i in range(0,len(molecules_list)):
-        restr_dict = restructure_dict(molecules_list[i])
-        try:
-            _id = restr_dict["chembl"]['inchi_key']
-            restr_dict["_id"] = _id
-        except KeyError:
-            pass
-        yield restr_dict
 
-def restructure_xref(xref_list):
-    """
-    Group the cross references field based on the source
-    Also change the field name
-    """
-    xref_output = defaultdict(list)
-    for _record in xref_list:
-        # note that the 'xref' field names are from the chembl datasource, not the parser
-        if 'xref_src' in _record and _record['xref_src'] == 'PubChem':
-            assert _record['xref_name'].startswith('SID: ')
-            xref_output['pubchem'].append({'sid': int(_record['xref_id'])})
-        elif 'xref_src' in _record and _record['xref_src'] == 'Wikipedia':
-            xref_output['wikipedia'].append({'url_stub': _record['xref_id']})
-        elif 'xref_src' in _record and _record['xref_src'] == 'TG-GATEs':
-            xref_output['tg-gates'].append({'name': _record['xref_name'], 'id': int(_record['xref_id'])})
-        elif 'xref_src' in _record and _record['xref_src'] == 'DailyMed':
-            xref_output['dailymed'].append({'name': _record['xref_name']})
-        elif 'xref_src' in _record and _record['xref_src'] == 'DrugCentral':
-            xref_output['drugcentral'].append({'name': _record['xref_name'], 'id': int(_record['xref_id'])})
-    return xref_output
+class JsonListTransformer(ABC):
+    @classmethod
+    @abstractmethod
+    def transform_to_dict(cls, entry_list):
+        pass
 
 
-def restructure_dict(dictionary):
-    restr_dict = dict()
-    _flag = 0
-    for key in list(dictionary): # this is for 1
-        if key == 'molecule_chembl_id':
-            restr_dict['_id']=dictionary[key]
-        if key == 'molecule_structures' and type(dictionary['molecule_structures'])==dict:
-            restr_dict['chembl'] = dictionary
-            _flag=1
-            for x,y in iter(dictionary['molecule_structures'].items()):
-                if x == 'standard_inchi_key':
-                    restr_dict['chembl'].update(dictionary)
-                    restr_dict['chembl'].update({'inchi_key':y})
-                if x == 'canonical_smiles':
-                    restr_dict['chembl']['smiles'] = y
-                if x == 'standard_inchi':
-                    restr_dict['chembl']['inchi'] = y
+class JsonFileAdapterMixin(JsonListTransformer, ABC):
+    @classmethod
+    def _read_raw_content(cls, file):
+        if not cls.entry_list_key:
+            raise ValueError("Class attribute `entry_list_key` not initialized")
 
-    if _flag == 0:
-        restr_dict['chembl'] = dictionary
-    if 'cross_references' in restr_dict['chembl'] and restr_dict['chembl']['cross_references']:
-        restr_dict['chembl']['xrefs'] = restructure_xref(restr_dict['chembl']['cross_references'])
+        entry_list = json.load(open(file))[cls.entry_list_key]
+        return entry_list
 
-    del restr_dict['chembl']['molecule_structures']
-    del restr_dict['chembl']['cross_references']
-    restr_dict = unlist(restr_dict)
-    # Add "CHEBI:" prefix, standardize the way representing CHEBI IDs
-    if 'chebi_par_id' in restr_dict['chembl'] and restr_dict['chembl']['chebi_par_id']:
-        restr_dict['chembl']['chebi_par_id'] = 'CHEBI:' + str(restr_dict['chembl']['chebi_par_id'])
-    else:
-        # clean, could be a None
-        restr_dict['chembl'].pop("chebi_par_id",None)
+    @classmethod
+    def _read_file_and_adapt_content(cls, file):
+        entry_list = cls._read_raw_content(file)
 
-    restr_dict = dict_sweep(restr_dict, vals=[None,".", "-", "", "NA", "None","none", " ", "Not Available", "unknown","null"])
-    restr_dict = value_convert_to_number(restr_dict, skipped_keys=["chebi_par_id","first_approval"])
-    restr_dict = boolean_convert(restr_dict, ["topical","oral","parenteral","dosed_ingredient","polymer_flag",
-        "therapeutic_flag","med_chem_friendly","molecule_properties.ro3_pass"])
-    return restr_dict
+        adapt_raw_content_op = getattr(cls, "adapt_raw_content", None)
+        if not callable(adapt_raw_content_op):
+            raise NotImplementedError("Class method `adapt_raw_content` not implemented")
 
+        return cls.adapt_raw_content(entry_list)
+
+    @classmethod
+    def read_files_and_adapt_contents(cls, file_iter):
+        files = list(file_iter)
+        if len(files) == 1:
+            return cls._read_file_and_adapt_content(files[0])
+        else:
+            # merge the entry lists into one and return
+            return list(chain.from_iterable(cls._read_file_and_adapt_content(f) for f in files))
+
+    @classmethod
+    def read_data(cls, file_iter):
+        entry_list = cls.read_files_and_adapt_contents(file_iter)
+        return cls.transform_to_dict(entry_list)
+
+
+class MoleculeCrossReferenceListTransformer(JsonListTransformer):
+    @classmethod
+    def transform_to_dict(cls, xref_list):
+        """
+        Group the cross references field based on the source
+        Also change the field name
+        """
+        xref_output = defaultdict(list)
+        for _record in xref_list:
+            # note that the 'xref' field names are from the chembl datasource, not the parser
+            if 'xref_src' in _record and _record['xref_src'] == 'PubChem':
+                assert _record['xref_name'].startswith('SID: ')
+                xref_output['pubchem'].append({'sid': int(_record['xref_id'])})
+            elif 'xref_src' in _record and _record['xref_src'] == 'Wikipedia':
+                xref_output['wikipedia'].append({'url_stub': _record['xref_id']})
+            elif 'xref_src' in _record and _record['xref_src'] == 'TG-GATEs':
+                xref_output['tg-gates'].append({'name': _record['xref_name'], 'id': int(_record['xref_id'])})
+            elif 'xref_src' in _record and _record['xref_src'] == 'DailyMed':
+                xref_output['dailymed'].append({'name': _record['xref_name']})
+            elif 'xref_src' in _record and _record['xref_src'] == 'DrugCentral':
+                xref_output['drugcentral'].append({'name': _record['xref_name'], 'id': int(_record['xref_id'])})
+        return xref_output
+
+
+class ClinicalTrialsReferenceListFilter:
+    @classmethod
+    def __create_clinical_trials_reference(cls, ref_id):
+        ref_url = 'https://clinicaltrials.gov/search?id="{}"'.format(ref_id)
+        # percent-encode the `ref_url`, skipping characters of "?", "=", "/", and ":"
+        # basically it does only one thing -- encoding each double quote to "%22"
+        ref_url = urllib.parse.quote(ref_url, safe="?=/:")
+
+        ref = {
+            "ref_id": ref_id,
+            'ref_type': 'ClinicalTrials',
+            'ref_url': ref_url
+        }
+
+        return ref
+
+    @classmethod
+    def filter(cls, ref_list):
+        """
+        Iterate the input list of ClinicalTrials references, split comma-separated references into multiple references
+        if found. E.g. the following reference should be split into 2:
+
+            {'ref_id': 'NCT00375713,NCT02447393',
+             'ref_type': 'ClinicalTrials',
+             'ref_url': 'https://clinicaltrials.gov/search?id=%22NCT00375713%22OR%22NCT02447393%22'}
+
+        Test case: https://www.ebi.ac.uk/chembl/compound_report_card/CHEMBL1575/#Indications
+
+        Args:
+            ref_list (list): a list of ClinicalTrials reference json objects
+
+        Returns:
+            the filtered references
+        """
+
+        for ref in ref_list:
+            if ref["ref_type"] == "ClinicalTrials" and "," in ref["ref_id"]:
+                for ref_id in ref["ref_id"].split(","):
+                    yield cls.__create_clinical_trials_reference(ref_id)
+            else:
+                yield ref
+
+
+class TargetAdapter(JsonFileAdapterMixin):
+    # key of the raw content to the entry list
+    entry_list_key = "targets"
+
+    # keys to preserve and group on for each entry in the entry list
+    primary_key = "target_chembl_id"
+    field_keys = ["pref_name", "target_type", "organism"]
+    preserved_keys = set([primary_key] + field_keys)
+
+    # we need to rename some field keys indicated by the following map
+    rekeying_map = {
+        # old_key: new_key
+        "pref_name": "target_name",
+        "organism": "target_organism"
+    }
+
+    @classmethod
+    def adapt_raw_content(cls, entry_list):
+        for entry in entry_list:
+            for key in list(entry):
+                if key not in cls.preserved_keys:
+                    del entry[key]
+
+                if key in cls.rekeying_map:
+                    new_key = cls.rekeying_map[key]
+                    entry[new_key] = entry.pop(key)
+
+        return entry_list
+
+    @classmethod
+    def transform_to_dict(cls, entry_list):
+        """
+        Transform the `entry_list` into one dict, each of whose entries has the 'target_chembl_id'
+        as key and the rest of fields as value.
+
+        E.g.
+            entry_list = [
+                {'target_chembl_id': 'CHEMBL3885640',
+                 'target_name': 'Sodium/potassium-transporting ATPase subunit alpha-2/alpha-3',
+                 'target_organism': 'Rattus norvegicus',
+                 'target_type': 'PROTEIN COMPLEX'},
+
+                {'target_chembl_id': 'CHEMBL2331043',
+                 'target_name': 'Sodium channel alpha subunit',
+                 'target_organism': 'Homo sapiens',
+                 'target_type': 'PROTEIN FAMILY'}
+            ]
+
+        after transformation we have:
+
+            return_dict = {
+                'CHEMBL3885640': {'target_name': 'Sodium/potassium-transporting ATPase subunit alpha-2/alpha-3',
+                                  'target_organism': 'Rattus norvegicus',
+                                  'target_type': 'PROTEIN COMPLEX'},
+                'CHEMBL2331043': {'target_name': 'Sodium channel alpha subunit',
+                                  'target_organism': 'Homo sapiens',
+                                  'target_type': 'PROTEIN FAMILY'}
+            }
+        """
+        ret_dict = {entry[cls.primary_key]: entry for entry in entry_list}
+        for _, entry in ret_dict.items():
+            del entry[cls.primary_key]
+
+        return ret_dict
+
+
+class DrugAdapter(JsonFileAdapterMixin):
+    # key of the raw content to the entry list
+    entry_list_key = "drugs"
+
+    # keys to preserve and group on for each entry in the entry list
+    primary_key = "molecule_chembl_id"
+    field_key = "first_approval"
+    preserved_keys = {primary_key, field_key}
+
+    @classmethod
+    def adapt_raw_content(cls, entry_list):
+        for entry in entry_list:
+            for key in list(entry):
+                if key not in cls.preserved_keys:
+                    del entry[key]
+
+        return entry_list
+
+    @classmethod
+    def transform_to_dict(cls, entry_list):
+        """
+        `entry_list` is a list of `<"molecule_chembl_id" : xxx, "first_approval": yyy>` dictionaries,
+        here we convert it into a `<xxx : yyy>` dictionary
+
+        E.g.
+
+            entry_list = [
+                {'molecule_chembl_id': 'CHEMBL2', 'first_approval': 1976},
+                {'molecule_chembl_id': 'CHEMBL3', 'first_approval': 1984}
+            ]
+
+        after transformation we have:
+
+            return_dict = {
+                'CHEMBL2' : 1976,
+                'CHEMBL3' : 1984
+            }
+        """
+        return {entry[cls.primary_key]: entry[cls.field_key] for entry in entry_list}
+
+
+class BindingSiteAdapter(JsonFileAdapterMixin):
+    # key of the raw content to the entry list
+    entry_list_key = "binding_sites"
+
+    # keys to preserve and group on for each entry in the entry list
+    primary_key = "site_id"
+    field_key = "site_name"
+    preserved_keys = {primary_key, field_key}
+
+    @classmethod
+    def adapt_raw_content(cls, entry_list):
+        for entry in entry_list:
+            for key in list(entry):
+                if key not in cls.preserved_keys:
+                    del entry[key]
+
+        return entry_list
+
+    @classmethod
+    def transform_to_dict(cls, entry_list):
+        """
+        `entry_list` is a list of `<"site_id" : xxx, "site_name": yyy>` dictionaries,
+        here we convert it into a `<xxx : yyy>` dictionary
+
+        E.g.
+
+            entry_list = [
+                {'site_id': 10278, 'site_name': 'GABA-A receptor; alpha-5/beta-3/gamma-2, Neur_chan_LBD domain'},
+                {'site_id': 10279, 'site_name': 'GABA-A receptor; alpha-5/beta-3/gamma-2, Neur_chan_LBD domain'}
+            ]
+
+        after transformation we have:
+
+            return_dict = {
+                10278 : 'GABA-A receptor; alpha-5/beta-3/gamma-2, Neur_chan_LBD domain',
+                10279 : 'GABA-A receptor; alpha-5/beta-3/gamma-2, Neur_chan_LBD domain'
+            }
+        """
+        return {entry[cls.primary_key]: entry[cls.field_key] for entry in entry_list}
+
+
+class MechanismAdapter(JsonFileAdapterMixin):
+    # key of the raw content to the entry list
+    entry_list_key = "mechanisms"
+
+    # keys to preserve and group on for each entry in the entry list
+    primary_key = "molecule_chembl_id"
+    field_keys = ["action_type", "mechanism_refs", "site_id", "target_chembl_id"]
+    preserved_keys = set([primary_key] + field_keys)
+
+    @classmethod
+    def adapt_raw_content(cls, entry_list):
+        for entry in entry_list:
+            for key in list(entry):
+                if key not in cls.preserved_keys:
+                    del entry[key]
+
+                """
+                Sixteen types of references found in mechanism json objects:
+                
+                    ref_types = [
+                        "ISBN", "PubMed", DailyMed", "Wikipedia", "Expert", "Other",
+                        "FDA", "DOI", "KEGG", "PubChem", "IUPHAR", "PMC", "InterPro", 
+                        "ClinicalTrials", "Patent", "UniProt"
+                    ]
+                    
+                Comma-separated references are found in mechanisms json object so far, so I skipped splitting 
+                "ClinicalTrials" references here as in `DrugIndicationAdapter`.
+                """
+                # if key == "mechanism_refs":
+                #     entry[key] = ...
+
+        return entry_list
+
+    @classmethod
+    def transform_to_dict(cls, entry_list):
+        def primary_key_fn(entry): return entry[cls.primary_key]
+
+        # Sorting is necessary here because `itertools.groupby()` does not combine non-consecutive groups
+        #     E.g. `[1, 1, 2, 2, 1, 1]` will be split into 3 groups, `[1, 1], [2, 2], [1, 1]`
+        # Another workaround is to use `pandas.DataFrame.groupby()`
+        entry_list.sort(key=primary_key_fn)
+        ret_dict = {key: list(group) for key, group in groupby(entry_list, key=primary_key_fn)}
+
+        for _, mechanism_list in ret_dict.items():
+            for mechanism in mechanism_list:
+                del mechanism[cls.primary_key]
+
+        return ret_dict
+
+
+class DrugIndicationAdapter(JsonFileAdapterMixin):
+    # key of the raw content to the entry list
+    entry_list_key = "drug_indications"
+
+    # keys to preserve and group on for each entry in the entry list
+    primary_key = "molecule_chembl_id"
+    secondary_key = "mesh_id"
+    field_keys = ["mesh_heading", "efo_id", "efo_term", "max_phase_for_ind", "indication_refs"]
+    preserved_keys = set([primary_key, secondary_key] + field_keys)
+
+    @classmethod
+    def adapt_raw_content(cls, entry_list):
+        for entry in entry_list:
+            for key in list(entry):
+                if key not in cls.preserved_keys:
+                    del entry[key]
+
+                """
+                Four types of references found in drug indications are:
+                
+                    ref_types = ["ClinicalTrials", "ATC", "DailyMed", "FDA"]
+                
+                I only found comma-separated references in "ClinicalTrials" type, e.g.
+                
+                    {'ref_id': 'NCT00375713,NCT02447393', 'ref_type': 'ClinicalTrials',
+                     'ref_url': 'https://clinicaltrials.gov/search?id=%22NCT00375713%22OR%22NCT02447393%22'}
+
+                Commas are also found in some "FDA" references but serves as part of the file names, e.g.
+                
+                    {'ref_id': 'label/2015/206352s003,021567s038lbl.pdf', 'ref_type': 'FDA',
+                     'ref_url': 'http://www.accessdata.fda.gov/drugsatfda_docs/label/2015/206352s003,021567s038lbl.pdf'}
+                
+                Commas are not found in the other two types of references.
+                
+                So here I only split comma-separated references in "ClinicalTrials"
+                """
+                if key == "indication_refs":
+                    entry[key] = list(ClinicalTrialsReferenceListFilter.filter(entry[key]))
+
+        return entry_list
+
+    @classmethod
+    def transform_to_dict(cls, entry_list):
+        def extract_molecule_id_and_merge_mesh_subgroups():
+            """
+            First we need to transform `entry_list`, a list of dictionaries into one dictionary.
+
+            E.g.
+                entry_list = [
+                    {'mesh_id': 'D006967', ..., 'molecule_chembl_id': 'CHEMBL1000'},
+                    {'mesh_id': 'D020754', ..., 'molecule_chembl_id': 'CHEMBL744'},
+                    {'mesh_id': 'D020754', ..., 'molecule_chembl_id': 'CHEMBL744'}
+                ]
+
+            will be transformed (via `groupby` operation) to:
+
+                ret_dict = {
+                    'CHEMBL744': [{'mesh_id': 'D020754', ...,}, {'mesh_id': 'D020754', ...,}]
+                    'CHEMBL1000': [{'mesh_id': 'D006967', ..., }]
+                }
+
+            Then Note that in each value list in the above dictionary, `efo_id`, `efo_term` and `indication_refs`
+            can be further merged under the same `mesh_id` (to be consistent with the results shown on ChEMBL webpages,
+            e.g https://www.ebi.ac.uk/chembl/compound_report_card/CHEMBL744/).
+
+            E.g. values in
+
+                ret_dict = {
+                    'CHEMBL744': [{'mesh_id': 'D020754', 'efo_id': 'Orphanet:98756', 'max_phase_for_ind': 3, ...},
+                                  {'mesh_id': 'D020754', 'efo_id': 'Orphanet:94147', 'max_phase_for_ind': 3, ...},
+                                  ...]
+                }
+
+            will be merged into:
+
+                ret_dict = {
+                    'CHEMBL744': [{'mesh_id': 'D020754',
+                                   'efo_id': ['Orphanet:98756', 'Orphanet:94147'],
+                                   'max_phase_for_ind': 3, ...},
+                                  ...]
+                }
+
+            This can be done by grouping by `mesh_id` for each `molecule_chembl_id`. After grouping, we process other
+            fields as following:
+
+            - `mesh_heading`: use the unique value
+                - because one-to-one (bijection) relationship is confirmed between `mesh_id` and `mesh_heading`
+            - `efo_id` and `efo_terms`: put all valid values into lists
+                - one-to-one (bijection) relationship is also confirmed between `efo_id` and `efo_terms`
+            - `indication_refs`: concat all the reference lists into one
+            - `max_phase_for_ind`: use the max value
+
+            Uniqueness does not hold for just a couple `max_phase_for_ind` entries for certain
+            `<molecule_chembl_id, mesh_id>` combinations, and we decide to use `max(max_phase_for_ind)` in these cases.
+            Uniqueness tests be by running the following code:
+
+            ```python
+            import pandas as pd
+            import glob
+
+            drug_indication_json_files = glob.iglob(os.path.join(SRC_ROOT_FOLDER, "drug_indication.*.json"))
+            entry_list = DrugIndicationAdapter.read_files_and_adapt_contents(drug_indication_json_files)
+
+            df = pd.DataFrame(entry_list)
+            for _, group in df.groupby("molecule_chembl_id"):
+                for __, subgroup in group.groupby("mesh_id"):
+                    if subgroup.shape[0] > 1:
+                        if len(subgroup.loc[:, "max_phase_for_ind"].unique()) > 1:
+                            print(subgroup.loc[:, ["molecule_chembl_id", "mesh_id", "max_phase_for_ind"]])
+            ```
+
+            Output will be like:
+
+            ```
+                  molecule_chembl_id  mesh_id  max_phase_for_ind
+            32263      CHEMBL1201610  D009103                  4
+            34415      CHEMBL1201610  D009103                  3
+                  molecule_chembl_id  mesh_id  max_phase_for_ind
+            16625      CHEMBL1201631  D003920                  3
+            32505      CHEMBL1201631  D003920                  4
+            32506      CHEMBL1201631  D003920                  3
+                  molecule_chembl_id  mesh_id  max_phase_for_ind
+            16185      CHEMBL1201631  D003924                  3
+            32512      CHEMBL1201631  D003924                  4
+            32513      CHEMBL1201631  D003924                  3
+            ```
+            """
+
+            def primary_key_fn(entry): return entry[cls.primary_key]
+            def secondary_key_fn(entry): return entry[cls.secondary_key]
+
+            def merge_mesh_subgroups(_group):
+                """
+                Further group the input `group` by "mesh_id" and merge the subgroups
+                """
+
+                # Sorting is necessary here because `itertools.groupby()` does not combine non-consecutive groups
+                #     E.g. `[1, 1, 2, 2, 1, 1]` will be split into 3 groups, `[1, 1], [2, 2], [1, 1]`
+                # Another workaround is to use `pandas.DataFrame.groupby()`
+                _group = list(_group)
+                _group.sort(key=secondary_key_fn)
+
+                for _, subgroup in groupby(_group, key=secondary_key_fn):
+                    # `subgroup` returned by `groupby` is an iterator; to reuse it below, save it as a list
+                    subgroup = list(subgroup)
+
+                    ret_dict = dict()  # the dict to be returned (actually yielded)
+
+                    # No matter whether `len(subgroup) > 1` or not, the following 2 fields are unique to each subgroup
+                    ret_dict["mesh_id"] = subgroup[0]["mesh_id"]
+                    ret_dict["mesh_heading"] = subgroup[0]["mesh_heading"]
+
+                    # if len(subgroup) == 1: ret_dict["max_phase_for_ind"] = subgroup[0]["max_phase_for_ind"]
+                    # `max` operation applies no matter if `len(subgroup) == 1`
+                    ret_dict["max_phase_for_ind"] = max(entry["max_phase_for_ind"] for entry in subgroup)
+
+                    """
+                    Corner cases of `efo_id` and `efo_term`:
+
+                    1. We found some `mesh_id` mapped to None values of `efo_id` and `efo_term`.
+                    2. ChEMBL UI will merge duplicated `efo_id` and `efo_term` entries while keeping duplicated 
+                    references.
+
+                    --------------------------------------
+
+                    Example 1: 
+
+                        molecule_chembl_id : 'CHEMBL1201631'
+                        mesh_id : 'D007006'
+                        efo_id : [None, None, None, 
+                                  'HP:0000044', 
+                                  'HP:0000044', 
+                                  'HP:0000044']
+                        efo_term: [None, None, None, 
+                                   'Hypogonadotrophic hypogonadism \
+                                   {http://www.co-ode.org/patterns#createdBy=\
+                                   "http://www.ebi.ac.uk/ontology/webulous#OPPL_pattern"}',
+                                   'Hypogonadotrophic hypogonadism \
+                                   {http://www.co-ode.org/patterns#createdBy=\
+                                   "http://www.ebi.ac.uk/ontology/webulous#OPPL_pattern"}',
+                                   'Hypogonadotrophic hypogonadism 
+                                   {http://www.co-ode.org/patterns#createdBy=\
+                                   "http://www.ebi.ac.uk/ontology/webulous#OPPL_pattern"}']
+
+                    However, `indication_refs` exist for such None entries of `efo_id` and `efo_terms`.
+
+                    See https://www.ebi.ac.uk/chembl/compound_report_card/CHEMBL1201631/ "Drug Indications" panel 
+                    for more details.
+
+                    No idea why ChEMBL has data like this.
+
+                    --------------------------------------
+
+                    Example 2: 
+
+                        molecule_chembl_id : 'CHEMBL1201631'
+                        mesh_id : 'D020528',
+                        efo_id: ['EFO:0003840', 'EFO:0003840', 'EFO:0003840'],
+                        efo_term: ['chronic progressive multiple sclerosis',
+                                   'chronic progressive multiple sclerosis',
+                                   'chronic progressive multiple sclerosis']
+
+                    On https://www.ebi.ac.uk/chembl/compound_report_card/CHEMBL1201610/ "Drug Indications" panel, 
+                    mesh_id 'D020528' has 1 efo_ids, 1 efo_terms, but 3 duplicated references 
+                    """
+
+                    # I did not find a None `efo_id` mapped to a non-None `efo_term`, or vice versa
+                    efo_id_list = [entry["efo_id"] for entry in subgroup if entry["efo_id"] is not None]
+                    efo_term_list = [entry["efo_term"] for entry in subgroup if entry["efo_term"] is not None]
+
+                    """
+                    Addendum: Kevin suggested the following format for `efo_id` and `efo_term`:
+
+                        efo: [{efo_id: 'EFO:0008520', efo_term: 'primary progressive multiple sclerosis'},
+                              {efo_id: 'EFO:0008522', efo_term: 'secondary progressive multiple sclerosis'},
+                              {efo_id: 'EFO:0003840', efo_term: 'chronic progressive multiple sclerosis'}]
+                              
+                    Addendum: Chunlei suggested trim the "efo_" prefixes in the sub-field names:
+
+                        efo: [{id: ..., term: ...}]
+                    """
+                    # ret_dict["efo"] = [{"efo_id": t[0], "efo_term": t[1]} for t in
+                    #                    {*zip(efo_id_list, efo_term_list)}]
+                    ret_dict["efo"] = [{"id": t[0], "term": t[1]} for t in
+                                       {*zip(efo_id_list, efo_term_list)}]
+
+                    indication_refs = chain.from_iterable([entry["indication_refs"] for entry in subgroup])
+                    # remove the duplicated references (dictionaries underlying) in the collection
+                    # see https://stackoverflow.com/a/9427216
+                    ret_dict["indication_refs"] = [dict(t) for t in
+                                                   {tuple(sorted(ref.items())) for ref in indication_refs}]
+
+                    yield ret_dict
+
+            # Sorting is necessary here because `itertools.groupby()` does not combine non-consecutive groups
+            #     E.g. `[1, 1, 2, 2, 1, 1]` will be split into 3 groups, `[1, 1], [2, 2], [1, 1]`
+            # Another workaround is to use `pandas.DataFrame.groupby()`
+            entry_list.sort(key=primary_key_fn)
+            for key, group in groupby(entry_list, key=primary_key_fn):
+                drug_ind_list = list(merge_mesh_subgroups(group))
+                yield key, drug_ind_list
+
+        return dict(extract_molecule_id_and_merge_mesh_subgroups())
+
+
+class MoleculeEntryTransformer:
+    @classmethod
+    def transform(cls, dictionary):
+        ret_dict = dict()
+        _flag = 0
+        for key in list(dictionary):
+            if key == 'molecule_chembl_id':
+                ret_dict['_id'] = dictionary[key]
+            if key == 'molecule_structures' and type(dictionary['molecule_structures']) == dict:
+                ret_dict['chembl'] = dictionary
+                _flag = 1
+                for x, y in iter(dictionary['molecule_structures'].items()):
+                    if x == 'standard_inchi_key':
+                        ret_dict['chembl'].update(dictionary)
+                        ret_dict['chembl'].update({'inchi_key': y})
+                    if x == 'canonical_smiles':
+                        ret_dict['chembl']['smiles'] = y
+                    if x == 'standard_inchi':
+                        ret_dict['chembl']['inchi'] = y
+
+        if _flag == 0:
+            ret_dict['chembl'] = dictionary
+        if 'cross_references' in ret_dict['chembl'] and ret_dict['chembl']['cross_references']:
+            ret_dict['chembl']['xrefs'] = MoleculeCrossReferenceListTransformer.transform_to_dict(
+                ret_dict['chembl']['cross_references'])
+
+        del ret_dict['chembl']['molecule_structures']
+        del ret_dict['chembl']['cross_references']
+
+        ret_dict = unlist(ret_dict)
+
+        # Add "CHEBI:" prefix, standardize the way representing CHEBI IDs
+        if 'chebi_par_id' in ret_dict['chembl'] and ret_dict['chembl']['chebi_par_id']:
+            ret_dict['chembl']['chebi_par_id'] = 'CHEBI:' + str(ret_dict['chembl']['chebi_par_id'])
+        else:
+            # clean, could be a None
+            ret_dict['chembl'].pop("chebi_par_id", None)
+
+        ret_dict = dict_sweep(ret_dict, vals=[None, ".", "-", "", "NA", "None", "none", " ", "Not Available",
+                                              "unknown", "null"])
+        ret_dict = value_convert_to_number(ret_dict, skipped_keys=["chebi_par_id", "first_approval"])
+        ret_dict = boolean_convert(ret_dict, ["topical", "oral", "parenteral", "dosed_ingredient", "polymer_flag",
+                                              "therapeutic_flag", "med_chem_friendly",
+                                              "molecule_properties.ro3_pass"])
+        return ret_dict
+
+
+class LoadDataFunction:
+    def __init__(self):
+        self.drug_indication_dict = None
+        self.mechanism_dict = None
+        self.drug_dict = None
+        self.target_dict = None
+        self.binding_site_dict = None
+
+    def pre_read(self, data_folder):
+        if (self.drug_indication_dict is not None) or \
+                (self.mechanism_dict is not None) or \
+                (self.drug_dict is not None) or \
+                (self.target_dict is not None) or \
+                (self.binding_site_dict is not None):
+            raise ValueError("LoadDataFunction already pre-read; should not call `pre_read()` again")
+
+        drug_indication_json_files = glob.iglob(data_folder, "drug_indication.*.json")
+        mechanism_json_files = glob.iglob(data_folder, "mechanism.*.json")
+        drug_json_files = glob.iglob(data_folder, "drug.*.json")
+        target_json_files = glob.iglob(data_folder, "target.*.json")
+        binding_site_json_files = glob.iglob(data_folder, "binding_site.*.json")
+
+        self.drug_indication_dict = DrugIndicationAdapter.read_data(drug_indication_json_files)
+        self.mechanism_dict = MechanismAdapter.read_data(mechanism_json_files)
+        self.drug_dict = DrugAdapter.read_data(drug_json_files)
+        self.target_dict = TargetAdapter.read_data(target_json_files)
+        self.binding_site_dict = BindingSiteAdapter.read_data(binding_site_json_files)
+
+        # Join `drug::first_approval` to `drug_indication`
+        for chembl_id, indication_list in self.drug_indication_dict.items():
+            """
+            Some data are missing in the original `drug` data source.
+
+            E.g. "CHEMBL1003" is not included in the `drug` json but 
+            https://www.ebi.ac.uk/chembl/compound_report_card/CHEMBL1003/ 
+            "drug indications" panel shows it was first approved in 1984.
+
+            Not sure what to do for such cases.
+            """
+            first_approval = self.drug_dict.get(chembl_id, None)
+            for indication in indication_list:
+                indication["first_approval"] = first_approval
+
+        # Join `binding_site::binding_site_name` to `mechanism`
+        # Join `target::target_type`, `target::target_organism` and `target::target_name` to `mechanism`
+        target_keys = ["target_type", 'target_organism', 'target_name']
+        for _, mechanism_list in self.mechanism_dict.items():
+            for mechanism in mechanism_list:
+                mechanism["binding_site_name"] = self.binding_site_dict.get(mechanism["site_id"], None)
+                del mechanism["site_id"]
+
+                target = self.target_dict.get(mechanism["target_chembl_id"], defaultdict(lambda: None))
+                for key in target_keys:
+                    mechanism[key] = target[key]
+
+    def __call__(self, input_file):
+        molecule_data = json.load(open(input_file))['molecules']
+        molecule_list = [MoleculeEntryTransformer.transform(entry) for entry in molecule_data]
+        for molecule in molecule_list:
+            molecule["chembl"]["drug_indications"] = self.drug_indication_dict.\
+                get(molecule["chembl"]["molecule_chembl_id"], [])
+            molecule["chembl"]["drug_mechanisms"] = self.mechanism_dict.\
+                get(molecule["chembl"]["molecule_chembl_id"], [])
+
+            try:
+                _id = molecule["chembl"]['inchi_key']
+                molecule["_id"] = _id
+            except KeyError:
+                pass
+
+            yield molecule

--- a/src/hub/dataload/sources/chembl/chembl_upload.py
+++ b/src/hub/dataload/sources/chembl/chembl_upload.py
@@ -4,19 +4,20 @@ Chembl uploader
 # pylint: disable=E0401, E0611
 import os
 import glob
+import asyncio
 import pymongo
 import biothings.hub.dataload.storage as storage
 from biothings.hub.dataload.uploader import ParallelizedSourceUploader
 from hub.dataload.uploader import BaseDrugUploader
 from hub.datatransform.keylookup import MyChemKeyLookup
-from .chembl_parser import load_data
+from .chembl_parser import LoadDataFunction
 
 
 SRC_META = {
     "url": 'https://www.ebi.ac.uk/chembl/',
-    "license_url" : "https://www.ebi.ac.uk/about/terms-of-use",
-    "license_url_short" : "http://bit.ly/2KAUCAm"
-    }
+    "license_url": "https://www.ebi.ac.uk/about/terms-of-use",
+    "license_url_short": "http://bit.ly/2KAUCAm"
+}
 
 
 class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
@@ -26,7 +27,8 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
 
     name = "chembl"
     storage_class = storage.RootKeyMergerStorage
-    __metadata__ = {"src_meta" : SRC_META}
+    load_data_fn = LoadDataFunction()
+    __metadata__ = {"src_meta": SRC_META}
 
     MOLECULE_PATTERN = "molecule.*.json"
     keylookup = MyChemKeyLookup(
@@ -49,10 +51,18 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
         json_files = glob.glob(os.path.join(self.data_folder, self.__class__.MOLECULE_PATTERN))
         return [(f,) for f in json_files]
 
+    def before_update_data(self):
+        self.__class__.load_data_fn.pre_read(self.data_folder)
+
+    @asyncio.coroutine
+    def update_data(self, batch_size, job_manager=None):
+        self.before_update_data()
+        yield from super(self, ParallelizedSourceUploader).update_date()
+
     def load_data(self, input_file):
         """load data from an input file"""
         self.logger.info("Load data from file '%s'" % input_file)
-        return self.keylookup(load_data, debug=True)(input_file)
+        return self.keylookup(self.__class__.load_data_fn, debug=True)(input_file)
 
     def post_update_data(self, *args, **kwargs):
         """create indexes following an update"""
@@ -74,304 +84,379 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
         mapping = {
             "chembl": {
                 "properties": {
+                    "drug_indications": {
+                        "properties": {
+                            "efo": {
+                                "properties": {
+                                    "id": {
+                                        "type": "keyword"
+                                    },
+                                    "term": {
+                                        "type": "text"
+                                    }
+                                }
+                            },
+                            "indication_refs": {
+                                "properties": {
+                                    "ref_id": {
+                                        "type": "keyword"
+                                    },
+                                    "ref_type": {
+                                        "type": "keyword"
+                                    },
+                                    "ref_url": {
+                                        "type": "text"
+                                    }
+                                }
+                            },
+                            "max_phase_for_ind": {
+                                "type": "integer"
+                            },
+                            "mesh_heading": {
+                                "type": "text"
+                            },
+                            "mesh_id": {
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "drug_mechanisms": {
+                        "properties": {
+                            "action_type": {
+                                "type": "keyword"
+                            },
+                            "binding_site_name": {
+                                "type": "text"
+                            },
+                            "mechanism_refs": {
+                                "properties": {
+                                    "ref_id": {
+                                        "type": "keyword"
+                                    },
+                                    "ref_type": {
+                                        "type": "keyword"
+                                    },
+                                    "ref_url": {
+                                        "type": "text"
+                                    }
+                                }
+                            },
+                            "target_chembl_id": {
+                                "type": "keyword"
+                            },
+                            "target_name": {
+                                "type": "text"
+                            },
+                            "target_organism": {
+                                "type": "text"
+                            },
+                            "target_type": {
+                                "type": "text"
+                            }
+                        }
+                    },
                     "biotherapeutic": {
                         "properties": {
                             "helm_notation": {
                                 "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                },
+                                "type": "keyword"
+                            },
                             "description": {
                                 "type": "text"
-                                },
+                            },
                             "biocomponents": {
                                 "properties": {
                                     "organism": {
                                         "type": "text"
-                                        },
+                                    },
                                     "tax_id": {
                                         "type": "integer"
-                                        },
+                                    },
                                     "sequence": {
                                         "type": "text"
-                                        },
+                                    },
                                     "component_id": {
                                         "type": "integer"
-                                        },
+                                    },
                                     "description": {
                                         "type": "text"
-                                        },
+                                    },
                                     "component_type": {
                                         "normalizer": "keyword_lowercase_normalizer",
-                                        "type": "keyword",
-                                        }
+                                        "type": "keyword"
                                     }
-                                },
+                                }
+                            },
                             "molecule_chembl_id": {
                                 "normalizer": "keyword_lowercase_normalizer",
                                 "type": "keyword",
-                                'copy_to': ['all'],
-                                }
+                                "copy_to": [
+                                    "all"
+                                ]
                             }
-                        },
+                        }
+                    },
                     "therapeutic_flag": {
                         "type": "boolean"
-                        },
+                    },
                     "usan_stem": {
                         "type": "text"
-                        },
+                    },
                     "molecule_chembl_id": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "molecule_properties": {
                         "properties": {
                             "heavy_atoms": {
                                 "type": "integer"
-                                },
+                            },
                             "acd_most_bpka": {
                                 "type": "float"
-                                },
+                            },
                             "mw_freebase": {
                                 "type": "float"
-                                },
+                            },
                             "num_ro5_violations": {
                                 "type": "integer"
-                                },
+                            },
                             "molecular_species": {
                                 "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                },
+                                "type": "keyword"
+                            },
                             "qed_weighted": {
                                 "type": "float"
-                                },
+                            },
                             "ro3_pass": {
                                 "type": "boolean"
-                                },
+                            },
                             "full_mwt": {
                                 "type": "float"
-                                },
+                            },
                             "num_lipinski_ro5_violations": {
                                 "type": "integer"
-                                },
+                            },
                             "rtb": {
                                 "type": "integer"
-                                },
+                            },
                             "psa": {
                                 "type": "float"
-                                },
+                            },
                             "alogp": {
                                 "type": "float"
-                                },
+                            },
                             "hbd": {
                                 "type": "integer"
-                                },
+                            },
                             "acd_most_apka": {
                                 "type": "float"
-                                },
+                            },
                             "hbd_lipinski": {
                                 "type": "integer"
-                                },
+                            },
                             "acd_logp": {
                                 "type": "float"
-                                },
+                            },
                             "full_molformula": {
                                 "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                },
+                                "type": "keyword"
+                            },
                             "aromatic_rings": {
                                 "type": "integer"
-                                },
+                            },
                             "hba_lipinski": {
                                 "type": "integer"
-                                },
+                            },
                             "mw_monoisotopic": {
                                 "type": "float"
-                                },
+                            },
                             "hba": {
                                 "type": "integer"
-                                },
+                            },
                             "acd_logd": {
                                 "type": "float"
-                                }
                             }
+                        }
                     },
                     "helm_notation": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "max_phase": {
                         "type": "integer"
-                        },
+                    },
                     "inorganic_flag": {
                         "type": "integer"
-                        },
+                    },
                     "usan_stem_definition": {
                         "type": "text"
-                        },
+                    },
                     "dosed_ingredient": {
                         "type": "boolean"
-                        },
+                    },
                     "chebi_par_id": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "withdrawn_reason": {
                         "type": "text"
-                        },
+                    },
                     "molecule_hierarchy": {
                         "properties": {
                             "parent_chembl_id": {
                                 "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                },
+                                "type": "keyword"
+                            },
                             "molecule_chembl_id": {
                                 "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                }
+                                "type": "keyword"
                             }
-                        },
+                        }
+                    },
                     "prodrug": {
                         "type": "integer"
-                        },
+                    },
                     "withdrawn_flag": {
                         "type": "boolean"
-                        },
+                    },
                     "usan_year": {
                         "type": "integer"
-                        },
+                    },
                     "parenteral": {
                         "type": "boolean"
-                        },
+                    },
                     "black_box_warning": {
                         "type": "integer"
-                        },
+                    },
                     "polymer_flag": {
                         "type": "boolean"
-                        },
+                    },
                     "molecule_synonyms": {
                         "properties": {
                             "molecule_synonym": {
                                 "type": "text"
-                                },
+                            },
                             "synonyms": {
                                 "type": "text"
-                                },
+                            },
                             "syn_type": {
                                 "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                }
+                                "type": "keyword"
                             }
-                        },
+                        }
+                    },
                     "atc_classifications": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "molecule_type": {
                         "type": "text"
-                        },
+                    },
                     "first_in_class": {
                         "type": "integer"
-                        },
+                    },
                     "inchi": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "structure_type": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "withdrawn_class": {
                         "type": "text"
-                        },
+                    },
                     "inchi_key": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "topical": {
                         "type": "boolean"
-                        },
+                    },
                     "oral": {
                         "type": "boolean"
-                        },
+                    },
                     "xrefs": {
                         "properties": {
                             "drugcentral": {
                                 "properties": {
                                     "id": {
                                         "type": "integer"
-                                        },
+                                    },
                                     "name": {
                                         "type": "text"
-                                        }
                                     }
-                                },
+                                }
+                            },
                             "tg-gates": {
                                 "properties": {
                                     "id": {
                                         "type": "integer"
-                                        },
+                                    },
                                     "name": {
                                         "type": "text"
-                                        }
                                     }
-                                },
+                                }
+                            },
                             "wikipedia": {
                                 "properties": {
                                     "url_stub": {
                                         "normalizer": "keyword_lowercase_normalizer",
-                                        "type": "keyword",
-                                        }
+                                        "type": "keyword"
                                     }
-                                },
+                                }
+                            },
                             "dailymed": {
                                 "properties": {
                                     "name": {
                                         "type": "text"
-                                        }
                                     }
-                                },
+                                }
+                            },
                             "pubchem": {
                                 "properties": {
                                     "sid": {
                                         "type": "integer"
-                                        }
                                     }
                                 }
                             }
-                        },
+                        }
+                    },
                     "chirality": {
                         "type": "integer"
-                        },
+                    },
                     "usan_substem": {
                         "type": "text"
-                        },
+                    },
                     "indication_class": {
                         "type": "text"
-                        },
+                    },
                     "withdrawn_country": {
                         "type": "text"
-                        },
+                    },
                     "withdrawn_year": {
                         "type": "integer"
-                        },
+                    },
                     "availability_type": {
                         "type": "integer"
-                        },
+                    },
                     "smiles": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword",
-                        },
+                        "type": "keyword"
+                    },
                     "natural_product": {
                         "type": "integer"
-                        },
+                    },
                     "pref_name": {
                         "type": "text",
-                        "copy_to": ["all"]
-                        },
+                        "copy_to": [
+                            "all"
+                        ]
+                    },
                     "first_approval": {
                         "type": "integer"
-                        }
                     }
+                }
             }
         }
 

--- a/src/hub/dataload/sources/chembl/chembl_upload.py
+++ b/src/hub/dataload/sources/chembl/chembl_upload.py
@@ -57,7 +57,7 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
     @asyncio.coroutine
     def update_data(self, batch_size, job_manager=None):
         self.before_update_data()
-        yield from super(self, ParallelizedSourceUploader).update_date()
+        yield from super(ChemblUploader, self).update_data(batch_size, job_manager)
 
     def load_data(self, input_file):
         """load data from an input file"""


### PR DESCRIPTION
This PR fixes [ChEMBL Parser missing information #67](https://github.com/biothings/mychem.info/issues/67).

Previously, we had only one data source (`molecule`) for ChEMBL API. To match the display on ChEMBL web interface (e.g. [CHEMBL744](https://www.ebi.ac.uk/chembl/compound/inspect/CHEMBL744)) , we need to enrich the `molecule` json objects by adding drug indications, drug mechanism fields. (Target predictions, although mentioned in the original issue, are not accessible via published API so far; we can wait for ChEMBL to refresh their APIs before handling this field.)

This fix introduced 5 extra data sources:

- `drug_indication`: 37,259 json objects
- `mechanism`: 5,134 json objects
- `drug`: 13,308 json objects
- `target`: 13,382 json objects
- `binding_site`: 14,342  json objects

Since the newly-introduced data source are much smaller than the root data source `molecule` (1,961,462  json objects), the enrichment is carried out in RAM. After augmented with the other 3 extra data sources, all `drug_indication` and `mechanism` data will be pre-read into 2 dictionaries by `ChemblUploader`. Then for each `molecule` entry, corresponding `drug_indication` and `mechanism` entries (bound by the same `molecule_chembl_id`) will be attached as new sub fields. The enriched `molecule` entries will then be indexed as usual and serve the API. Samples of the enriched json objects can be found in [Gist: erikyao/Sample Json Responses.md](https://gist.github.com/erikyao/82c3b66b11df02e82c912407a8190fd8)