### PR TITLE
Enhancement to Issue#67 and ChEMBL download control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ src/config_prod.py
 src/run/*.pickle
 src/run/done/*.pickle
 src/bin/ssh_host*
+
+src/.idea
+
 # Emacs
 *~
 \#*\#

--- a/src/hub/dataload/sources/chembl/chembl_dump.py
+++ b/src/hub/dataload/sources/chembl/chembl_dump.py
@@ -9,7 +9,7 @@ import config
 
 biothings.config_for_app(config)
 
-from config import DATA_ARCHIVE_ROOT
+from config import DATA_ARCHIVE_ROOT, HUB_MAX_WORKERS
 from biothings.hub.dataload.dumper import HTTPDumper
 from biothings.utils.common import iter_n
 
@@ -38,11 +38,6 @@ class ChemblDumper(HTTPDumper):
         "drug_indication": "https://www.ebi.ac.uk/chembl/api/data/drug_indication.json",
         "mechanism": "https://www.ebi.ac.uk/chembl/api/data/mechanism.json",
 
-        # Used to augment `first_approval` field to `drug_indication`
-        # E.g. if a drug has `first_approval` of 1990, all its drug indications will have a `first_approval`
-        #   field of 1990
-        # "drug": "https://www.ebi.ac.uk/chembl/api/data/drug.json",
-
         # Used to join with `mechanism` by `target_chembl_id`
         "target": "https://www.ebi.ac.uk/chembl/api/data/target.json",
         # used to join with `mechanism` by `site_id`
@@ -50,7 +45,7 @@ class ChemblDumper(HTTPDumper):
     }
 
     SCHEDULE = "0 12 * * *"
-    SLEEP_BETWEEN_DOWNLOAD = 0.1
+    MAX_PARALLEL_DUMP = HUB_MAX_WORKERS // 2
 
     # number of documents in each download job, i.e. number of documents in each .part* file
     TO_DUMP_DOWNLOAD_SIZE = 1000

--- a/src/hub/dataload/sources/chembl/chembl_dump.py
+++ b/src/hub/dataload/sources/chembl/chembl_dump.py
@@ -27,7 +27,6 @@ class ChemblDumper(HTTPDumper):
     - 1,961,462 "molecule" json objects
     - 5,134 "mechanism" json objects
     - 37,259 "drug_indication" json objects
-    - 13,308 "drug" json objects
     - 13,382 "target" json objects
     - 14,342 "binding_site" json objects
     """
@@ -42,7 +41,7 @@ class ChemblDumper(HTTPDumper):
         # Used to augment `first_approval` field to `drug_indication`
         # E.g. if a drug has `first_approval` of 1990, all its drug indications will have a `first_approval`
         #   field of 1990
-        "drug": "https://www.ebi.ac.uk/chembl/api/data/drug.json",
+        # "drug": "https://www.ebi.ac.uk/chembl/api/data/drug.json",
 
         # Used to join with `mechanism` by `target_chembl_id`
         "target": "https://www.ebi.ac.uk/chembl/api/data/target.json",
@@ -51,6 +50,7 @@ class ChemblDumper(HTTPDumper):
     }
 
     SCHEDULE = "0 12 * * *"
+    SLEEP_BETWEEN_DOWNLOAD = 0.1
 
     # number of documents in each download job, i.e. number of documents in each .part* file
     TO_DUMP_DOWNLOAD_SIZE = 1000
@@ -140,7 +140,7 @@ class ChemblDumper(HTTPDumper):
             """
             Now we need to scroll the API endpoints. Let's get the total number of records
             and generate URLs for each call to parallelize the downloads for each type of source data, 
-            i.e. "molecule", "mechanism", "drug_indication", "drug", "target" and "binding_site".
+            i.e. "molecule", "mechanism", "drug_indication", "target" and "binding_site".
             
             The partition size is set to 1000 json objects (represented by `TO_DUMP_DOWNLOAD_SIZE`). 
             
@@ -185,7 +185,7 @@ class ChemblDumper(HTTPDumper):
 
                 """
                 For each "molecule" json object, we only fetch the value associated with the "molecules" key.
-                This rule also applies to "mechanism", "drug_indication", "drug", "target" and "binding_site" 
+                This rule also applies to "mechanism", "drug_indication", "target" and "binding_site" 
                 json objects.
                 """
                 data_key = src_data_name + "s"

--- a/src/hub/dataload/sources/chembl/chembl_parser.py
+++ b/src/hub/dataload/sources/chembl/chembl_parser.py
@@ -650,11 +650,11 @@ class LoadDataFunction:
         self.binding_site_dict = None
 
     def pre_read(self, data_folder):
-        if (self.drug_indication_dict is not None) or \
-                (self.mechanism_dict is not None) or \
-                (self.target_dict is not None) or \
-                (self.binding_site_dict is not None):
-            raise ValueError("LoadDataFunction already pre-read; should not call `pre_read()` again")
+        # if (self.drug_indication_dict is not None) or \
+        #         (self.mechanism_dict is not None) or \
+        #         (self.target_dict is not None) or \
+        #         (self.binding_site_dict is not None):
+        #     raise ValueError("LoadDataFunction already pre-read; should not call `pre_read()` again")
 
         drug_indication_json_files = glob.iglob(os.path.join(data_folder, "drug_indication.*.json"))
         mechanism_json_files = glob.iglob(os.path.join(data_folder, "mechanism.*.json"))
@@ -687,9 +687,10 @@ class LoadDataFunction:
 
             if drug_indications is not None:
                 # Join `molecule::first_approval` to `drug_indication::first_approval`
-                first_approval = molecule["chembl"]["first_approval"]
-                for indication in drug_indications:
-                    indication["first_approval"] = first_approval
+                first_approval = molecule["chembl"].get("first_approval", None)
+                if first_approval:
+                    for indication in drug_indications:
+                        indication["first_approval"] = first_approval
 
                 molecule["chembl"]["drug_indications"] = drug_indications
 

--- a/src/hub/dataload/sources/chembl/chembl_upload.py
+++ b/src/hub/dataload/sources/chembl/chembl_upload.py
@@ -4,13 +4,11 @@ Chembl uploader
 # pylint: disable=E0401, E0611
 import os
 import glob
-import asyncio
-import pymongo
 import biothings.hub.dataload.storage as storage
 from biothings.hub.dataload.uploader import ParallelizedSourceUploader
 from hub.dataload.uploader import BaseDrugUploader
 from hub.datatransform.keylookup import MyChemKeyLookup
-from .chembl_parser import LoadDataFunction
+from .chembl_parser import NonMoleculeFileLoader, load_molecule_file
 
 
 SRC_META = {
@@ -27,7 +25,6 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
 
     name = "chembl"
     storage_class = storage.RootKeyMergerStorage
-    load_data_fn = LoadDataFunction()
     __metadata__ = {"src_meta": SRC_META}
 
     MOLECULE_PATTERN = "molecule.*.json"
@@ -46,23 +43,21 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
 
     def jobs(self):
         """
-        this will generate arguments for self.load.data() method, allowing parallelization
+        this method will be called by self.update_data() and then generate arguments for self.load.data() method,
+        allowing parallelization
         """
-        json_files = glob.glob(os.path.join(self.data_folder, self.__class__.MOLECULE_PATTERN))
-        return [(f,) for f in json_files]
+        molecule_files = glob.glob(os.path.join(self.data_folder, self.__class__.MOLECULE_PATTERN))
 
-    def before_update_data(self):
-        self.__class__.load_data_fn.pre_read(self.data_folder)
+        non_molecule_file_loader = NonMoleculeFileLoader()
+        non_molecule_file_loader.load(self.data_folder)
 
-    @asyncio.coroutine
-    def update_data(self, batch_size, job_manager=None):
-        self.before_update_data()
-        yield from super(ChemblUploader, self).update_data(batch_size, job_manager)
+        return [(molecule_file, non_molecule_file_loader) for molecule_file in molecule_files]
 
-    def load_data(self, input_file):
+    def load_data(self, molecule_file, non_molecule_file_loader):
         """load data from an input file"""
-        self.logger.info("Load data from file '%s'" % input_file)
-        return self.keylookup(self.__class__.load_data_fn, debug=True)(input_file)
+        self.logger.info("Load data from file '%s'" % molecule_file)
+
+        return self.keylookup(load_molecule_file, debug=True)(molecule_file, non_molecule_file_loader)
 
     def post_update_data(self, *args, **kwargs):
         """create indexes following an update"""
@@ -98,13 +93,25 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
                             },
                             "indication_refs": {
                                 "properties": {
-                                    "ref_id": {
+                                    "id": {
                                         "type": "keyword"
                                     },
-                                    "ref_type": {
+                                    "type": {
                                         "type": "keyword"
                                     },
-                                    "ref_url": {
+                                    "url": {
+                                        "type": "text"
+                                    },
+                                    "ClinicalTrials": {
+                                        "type": "text"
+                                    },
+                                    "ATC": {
+                                        "type": "text"
+                                    },
+                                    "DailyMed": {
+                                        "type": "text"
+                                    },
+                                    "FDA": {
                                         "type": "text"
                                     }
                                 }
@@ -130,13 +137,61 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
                             },
                             "mechanism_refs": {
                                 "properties": {
-                                    "ref_id": {
+                                    "id": {
                                         "type": "keyword"
                                     },
-                                    "ref_type": {
+                                    "type": {
                                         "type": "keyword"
                                     },
-                                    "ref_url": {
+                                    "url": {
+                                        "type": "text"
+                                    },
+                                    "ISBN": {
+                                        "type": "text"
+                                    },
+                                    "PubMed": {
+                                        "type": "text"
+                                    },
+                                    "DailyMed": {
+                                        "type": "text"
+                                    },
+                                    "Wikipedia": {
+                                        "type": "text"
+                                    },
+                                    "Expert": {
+                                        "type": "text"
+                                    },
+                                    "Other": {
+                                        "type": "text"
+                                    },
+                                    "FDA": {
+                                        "type": "text"
+                                    },
+                                    "DOI": {
+                                        "type": "text"
+                                    },
+                                    "KEGG": {
+                                        "type": "text"
+                                    },
+                                    "PubChem": {
+                                        "type": "text"
+                                    },
+                                    "IUPHAR": {
+                                        "type": "text"
+                                    },
+                                    "PMC": {
+                                        "type": "text"
+                                    },
+                                    "InterPro": {
+                                        "type": "text"
+                                    },
+                                    "ClinicalTrials": {
+                                        "type": "text"
+                                    },
+                                    "Patent": {
+                                        "type": "text"
+                                    },
+                                    "UniProt": {
                                         "type": "text"
                                     }
                                 }


### PR DESCRIPTION
## Summary

This is a follow-up to [Issue#67](https://github.com/biothings/mychem.info/issues/67) and [PR#93](https://github.com/biothings/mychem.info/pull/93). 

## Changes in Drug Indication and Mechanism Reference Format

E.g. In the previous PR, a drug-indication reference is like:

```json
"indication_refs": [
  {
    "ref_id": "NCT01910259",
    "ref_type": "ClinicalTrials",
    "ref_url": "https://clinicaltrials.gov/search?id=%22NCT01910259%22"
  }
]
```

The new format will be:

```
"indication_refs": [
  {
    "ClinicalTrials": "NCT01910259",
    "id": "NCT01910259",
    "type": "ClinicalTrials",
    "url": "https://clinicaltrials.gov/search?id=%22NCT01910259%22"
  }
]
```

Simply put:

- Shorter keys are used: `ref_id` => `id`, `ref_type` => `type`, `ref_url` => `url`
- Added a new entry for each reference object with its `ref_type` value as key, its `ref_id` value as value

A sample response can be found at [https://gist.github.com/erikyao/82c3b66b11df02e82c912407a8190fd8](https://gist.github.com/erikyao/82c3b66b11df02e82c912407a8190fd8)

## Changes in download sources

In this PR, we no longer download (~13,000) `Drug` documents from [https://www.ebi.ac.uk/chembl/api/data/drug.json](https://www.ebi.ac.uk/chembl/api/data/drug.json) because I found the `drug_indication["first_approval"]` field can be appended from `molecule["first_approval"]`

![](https://live.staticflickr.com/65535/51037671277_6287b2ef51_k_d.jpg)

Fields in bold are treated as "primary keys"; fields in baby-blue are appended to `drug_indication` documents by key; fields in purple are appended to `mechanism` documents by key; a red cross means "no longer used".

<!--
Source code in https://dbdiagram.io/

// Creating tables
Table Molecule as M {
  molecule_chembl_id string [pk]
  first_approval int
  other_fields string
}

Table Target as T {
  target_chembl_id string [pk]
  pref_name string
  target_type string
  organism string
 }
 
Table Binding_Site as BS {
  site_id string [pk]
  site_name string
}

Table Mechanism as DM {
  molecule_chembl_id string [pk]
  action_type string
  mechanism_refs list
  site_id string
  target_chembl_id string
}

Table DrugIndication as DI {
  molecule_chembl_id string [pk]
  mesh_id string
  mesh_heading string
  efo_id list
  efo_term list
  max_phase_for_ind int
  indication_refs list
}

Table Drug as D {
  molecule_chembl_id string [pk]
  first_approval int
}

// Creating references
// You can also define relaionship separately
// > many-to-one; < one-to-many; - one-to-one
Ref: DM.target_chembl_id - T.target_chembl_id
Ref: DM.site_id - BS.site_id

Ref: M.molecule_chembl_id - DM.molecule_chembl_id
Ref: M.molecule_chembl_id - DI.molecule_chembl_id
-->

## Bugfix: `TypeError: can't pickle _thread.lock objects`

This is a very subtle one. 

Originally the `ChemblUploader` object will call `self.update_data()` (inherited from `ParallelizedSourceUploader`), which then make a `deepcopy(self.load_data)` to each `upload_worker` awaiting to be sent to the process queue. See [uploader.py#L624](https://github.com/biothings/biothings.api/blob/master/biothings/hub/dataload/uploader.py#L624).

If we overwrote `update_data()` in `ChemblUploader`, because it is a coroutine, we may have to write like this:

```python
class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
    @asyncio.coroutine
    def update_data(self, batch_size, job_manager=None):
        # New extra procedures go here
        # E.g. pre-read non-molecule files blah blah

        yield from super(BaseDrugUploader, self).update_data(batch_size, job_manager)
```

I guess (not 100% sure because I've not studied the underlying mechanism of coroutines) in this way `ChemblUploader` has to wait on the coroutine from its super class and somehow obtains a `_thread.lock` object, which would fail the `deepcopy(self.load_data)` call and raise the error in the title.

P.S. `deepcopy(self.load_data)` would essentially make a `deepcopy(self)` because I believe it has to make `self.load_data` a closure.

Workaround: Do not overwrite `update_data()` in `ChemblUploader`. Put the newly-added procedures as arguments to be distributed from `jobs()`.

## ChEMBL download control

Upon last PR, Kevin told me occasionally ChEMBL will reject several downloading requests. Considering we would have more than 2,000 molecule files (for `ChEMBL_28`) to download and we are using a process pool to download in parallel, I hypothesize we might have to control the speed of downloading a little bit.

There seems two ways for this purpose:

- add a non-zero `SLEEP_BETWEEN_DOWNLOAD` field, inherited from `BaseDumper` (see [dumper.py#L39](https://github.com/biothings/biothings.api/blob/master/biothings/hub/dataload/dumper.py#L39)), to our `ChemblDumper`. Or,
- add a numeric `MAX_PARALLEL_DUMP` field (see [dumper.py#L37](https://github.com/biothings/biothings.api/blob/master/biothings/hub/dataload/dumper.py#L37)) instead

After I read the source code I found `SLEEP_BETWEEN_DOWNLOAD` does not function as its name implies. The real effect for this field is to control the time of sleep (in second) for coroutines (not the processes), when they (the coroutines) are adding the downloading tasks to the process pool. Note that the implementation of our process pool, `ProcessPoolExecutor`, actually has a queue for pending tasks, `SLEEP_BETWEEN_DOWNLOAD` can only deter the fullness of the process pool for only once.

In this PR, I've set `MAX_PARALLEL_DUMP == HUB_MAX_WORKERS // 2`. With `HUB_MAX_WORKERS` being 14 on our server, there will be only 7 coroutines allowed to add downloading tasks concurrently at anytime. Another coroutine must wait for a downloading task to finish so it can add its own task to the process pool. In this way, there will at most 7 processes running inside the pool all the time.