### PR TITLE
Fix pubchem parser

### DIFF
--- a/src/hub/dataload/sources/pubchem/pubchem_parser.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_parser.py
@@ -38,187 +38,220 @@ def dict_to_snake_case(d, skipped_keys=[]):
 def load_annotations(input_file):
     """Main function to load data from individual xml files"""
 
-    # keep track of tags, whereby these change to true the next item in the appropriate element
-    # will be the relevant value
-    try:
-        PC_count = False
-        inchi = False
-        inchikey = False
-        hydrogen_bond_acceptor = False
-        hydrogen_bond_donor = False
-        rotatable_bond = False
-        iupac = False
-        logp = False
-        mass = False
-        molecular_formula = False
-        molecular_weight = False
-        smiles = False
-        topological = False
-        monoisotopic_weight = False
-        complexity = False
+    # use gzip to read the .gz file
+    unzipped_file = gzip.open(input_file, 'rb')
 
-        # use gzip to read the .gz file
-        unzipped_file = gzip.open(input_file, 'rb')
+    """ Keep track of tags, whereby these change to true the next item in the appropriate element
+    will be the relevant value
+    """
+    PC_count = False
+    inchi = False
+    inchikey = False
+    hydrogen_bond_acceptor = False
+    hydrogen_bond_donor = False
+    rotatable_bond = False
+    iupac = False
+    logp = False
+    mass = False
+    molecular_formula = False
+    molecular_weight = False
+    smiles = False
+    topological = False
+    monoisotopic_weight = False
+    complexity = False
 
-        # use ET.iterparse to loop through the xml line by line
-        for event, elem in ET.iterparse(unzipped_file, events=("start", "end")):
-            try:
-                prefix, has_namespace, postfix = elem.tag.partition('}')
-                if has_namespace:
-                    elem.tag = postfix  # strip all namespaces
-                # all of the compound properties will be inside this element
-                if((elem.tag == "PC-CompoundType_id_cid") & (event == 'start')):
-                    current_compound = {}
-                    compound_data = {}
-                    # cid is _id, unless inchikey exists (overwritten below)
+    """ Use ET.iterparse to loop through the xml line by line.
+    Note:
+    The 'end' events are used whenever we need to obtain elem.text field, because
+    the text, tail, and children of an element are not necessarily present when receiving
+    the start event. Only the end event guarantees that the Element has been parsed completely.
+    """
+    for event, elem in ET.iterparse(unzipped_file, events=("start", "end")):
+        prefix, has_namespace, postfix = elem.tag.partition('}')
+        if has_namespace:
+            elem.tag = postfix  # strip all namespaces
+        # Maximum one of these flags sould be activated at any given time
+        flags = [PC_count, inchi, inchikey, hydrogen_bond_acceptor, hydrogen_bond_donor,
+                 rotatable_bond, iupac, logp, mass, molecular_formula, molecular_weight,
+                 smiles, topological, monoisotopic_weight, complexity]
+        assert sum(flags) <= 1, "Bad parsing. Only one flag at most should be active."
+        # all of the compound properties will be inside this element
+        if((elem.tag == "PC-CompoundType_id_cid") & (event == 'end')):
+            # Start a new compound record
+            current_compound = {}
+            compound_data = {}
+
+            # Reset flags
+            PC_count = False
+            inchi = False
+            inchikey = False
+            hydrogen_bond_acceptor = False
+            hydrogen_bond_donor = False
+            rotatable_bond = False
+            iupac = False
+            logp = False
+            mass = False
+            molecular_formula = False
+            molecular_weight = False
+            smiles = False
+            topological = False
+            monoisotopic_weight = False
+            complexity = False
+
+            compound_data["cid"] = elem.text
+            compound_data["iupac"] = {}
+            compound_data["smiles"] = {}
+            assert elem.text != None, "Every document must have a CID."
+
+        elif((elem.tag == "PC-Compound") & (event == 'end')):
+            # Document parsing is complete
+            current_compound["pubchem"] = compound_data
+            assert current_compound.get("_id"), "Document {} is missing an _id".format(current_compound)
+            # Convert numeric values to float or integer
+            current_compound = value_convert_to_number(current_compound)
+            # Convert keys to snake_case
+            current_compound = dict_to_snake_case(current_compound)
+            # yield the compound
+            yield(current_compound)
+            # clear element from memory
+            elem.clear()
+
+        elif((elem.tag == "PC-Compound_charge") & (event == 'end')):
+            if(elem.text):
+                compound_data["formal_charge"] = elem.text
+        elif((elem.tag == "PC-Count") & (event == 'start')):
+            PC_count = True
+        elif((elem.tag == "PC-Count") & (event == 'end')):
+            PC_count = False
+        elif(PC_count):
+            if(elem.text):
+                if((elem.tag == "PC-Count_heavy-atom") & (event == 'end')):
+                    compound_data["heavy_atom_count"] = elem.text
+                elif((elem.tag == "PC-Count_atom-chiral-def") & (event == 'end')):
+                    compound_data["defined_chiral_atom_count"] = elem.text
+                elif((elem.tag == "PC-Count_bond-chiral-def") & (event == 'end')):
+                    compound_data["defined_chiral_bond_count"] = elem.text
+                elif((elem.tag == "PC-Count_atom-chiral-undef") & (event == 'end')):
+                    compound_data["undefined_chiral_atom_count"] = elem.text
+                elif((elem.tag == "PC-Count_bond-chiral-undef") & (event == 'end')):
+                    compound_data["undefined_chiral_bond_count"] = elem.text
+                elif((elem.tag == "PC-Count_isotope-atom") & (event == 'end')):
+                    compound_data["isotope_atom_count"] = elem.text
+                elif((elem.tag == "PC-Count_covalent-unit") & (event == 'end')):
+                    compound_data["covalent_unit_count"] = elem.text
+                elif((elem.tag == "PC-Count_tautomers") & (event == 'end')):
+                    compound_data["tautomers_count"] = elem.text
+        elif((elem.tag == "PC-Count") & (event == 'start')):
+            PC_count = True
+        elif((elem.tag == "PC-Count") & (event == 'end')):
+            PC_count = False
+
+        elif((elem.tag == "PC-Urn_label") & (event == 'end')):
+            if(elem.text == 'InChI'):
+                inchi = True
+            elif(elem.text == 'InChIKey'):
+                inchikey = True
+            elif(elem.text == 'IUPAC Name'):
+                iupac = True
+            elif(elem.text == "Log P"):
+                logp = True
+            elif(elem.text == "Mass"):
+                mass = True
+            elif(elem.text == "Molecular Formula"):
+                molecular_formula = True
+            elif(elem.text == "Molecular Weight"):
+                molecular_weight = True
+            elif(elem.text == "SMILES"):
+                smiles = True
+            elif(elem.text == "Topological"):
+                topological = True
+            elif(elem.text == "Weight"):
+                monoisotopic_weight = True
+            elif(elem.text == "Compound Complexity"):
+                complexity = True
+
+        elif((elem.tag == "PC-Urn_name") & (event == 'end')):
+            if(elem.text == 'Hydrogen Bond Acceptor'):
+                hydrogen_bond_acceptor = True
+            elif(elem.text == 'Hydrogen Bond Donor'):
+                hydrogen_bond_donor = True
+            elif(elem.text == 'Rotatable Bond'):
+                rotatable_bond = True
+            elif(iupac):
+                iupac_key = elem.text
+            elif(smiles):
+                smiles_key = elem.text
+
+        elif((elem.tag == "PC-InfoData_value_sval") & (event == 'end')):
+            if(inchi):
+                if(elem.text):
+                    compound_data["inchi"] = elem.text
+                inchi = False
+            elif(inchikey):
+                if(elem.text):
                     current_compound["_id"] = elem.text
-                    compound_data["cid"] = elem.text
-                    compound_data["iupac"] = {}
-                    compound_data["smiles"] = {}
-                elif((elem.tag == "PC-Compound") & (event == 'end')):
-                    current_compound["pubchem"] = compound_data
-                    # rarely, some will be missing a cid. make sure this isn't the case
-                    if(current_compound["_id"]):
-                        # Convert numeric values to float or integer
-                        current_compound = value_convert_to_number(current_compound)
-                        # Convert keys to snake_case
-                        current_compound = dict_to_snake_case(current_compound)
-                        # yield the compound
-                        yield(current_compound)
-                    # clear element from memory
-                    elem.clear()
-                elif((elem.tag == "PC-Compound_charge") & (event == 'start')):
+                    compound_data["inchikey"] = elem.text
+                inchikey = False
+            elif(iupac):
+                if(iupac_key):
                     if(elem.text):
-                        compound_data["formal_charge"] = elem.text
-                elif((elem.tag == "PC-Count") & (event == 'start')):
-                    PC_count = True
-                elif((elem.tag == "PC-Count") & (event == 'end')):
-                    PC_count = False
-                elif(PC_count):
+                        compound_data['iupac'][iupac_key] = elem.text
+                iupac = False
+            elif(molecular_weight):
+                if(elem.text):
+                    compound_data["molecular_weight"] = elem.text
+                molecular_weight = False
+            elif(monoisotopic_weight):
+                if(elem.text):
+                    compound_data["monoisotopic_weight"] = elem.text
+                monoisotopic_weight = False
+            elif(mass):
+                if(elem.text):
+                    compound_data["exact_mass"] = elem.text
+                mass = False
+            elif(molecular_formula):
+                if(elem.text):
+                    compound_data["molecular_formula"] = elem.text
+                molecular_formula = False
+            elif(smiles):
+                if(smiles_key):
                     if(elem.text):
-                        if((elem.tag == "PC-Count_heavy-atom") & (event == 'start')):
-                            compound_data["heavy_atom_count"] = elem.text
-                        elif((elem.tag == "PC-Count_atom-chiral-def") & (event == 'start')):
-                            compound_data["defined_chiral_atom_count"] = elem.text
-                        elif((elem.tag == "PC-Count_bond-chiral-def") & (event == 'start')):
-                            compound_data["defined_chiral_bond_count"] = elem.text
-                        elif((elem.tag == "PC-Count_atom-chiral-undef") & (event == 'start')):
-                            compound_data["undefined_chiral_atom_count"] = elem.text
-                        elif((elem.tag == "PC-Count_bond-chiral-undef") & (event == 'start')):
-                            compound_data["undefined_chiral_bond_count"] = elem.text
-                        elif((elem.tag == "PC-Count_isotope-atom") & (event == 'start')):
-                            compound_data["isotope_atom_count"] = elem.text
-                        elif((elem.tag == "PC-Count_covalent-unit") & (event == 'start')):
-                            compound_data["covalent_unit_count"] = elem.text
-                        elif((elem.tag == "PC-Count_tautomers") & (event == 'start')):
-                            compound_data["tautomers_count"] = elem.text
-                elif((elem.tag == "PC-Count") & (event == 'start')):
-                    PC_count = True
-                elif((elem.tag == "PC-Count") & (event == 'end')):
-                    PC_count = False
+                        compound_data['smiles'][smiles_key] = elem.text
+                smiles = False
 
-                elif((elem.tag == "PC-Urn_label") & (event == 'start')):
-                    if(elem.text == 'InChI'):
-                        inchi = True
-                    elif(elem.text == 'InChIKey'):
-                        inchikey = True
-                    elif(elem.text == 'IUPAC Name'):
-                        iupac = True
-                    elif(elem.text == "Log P"):
-                        logp = True
-                    elif(elem.text == "Mass"):
-                        mass = True
-                    elif(elem.text == "Molecular Formula"):
-                        molecular_formula = True
-                    elif(elem.text == "Molecular Weight"):
-                        molecular_weight = True
-                    elif(elem.text == "SMILES"):
-                        smiles = True
-                    elif(elem.text == "Topological"):
-                        topological = True
-                    elif(elem.text == "Weight"):
-                        monoisotopic_weight = True
-                    elif(elem.text == "Compound Complexity"):
-                        complexity = True
+        elif((elem.tag == "PC-InfoData_value_ival") & (event == 'end')):
+            if(hydrogen_bond_acceptor):
+                if(elem.text):
+                    compound_data["hydrogen_bond_acceptor_count"] = elem.text
+                hydrogen_bond_acceptor = False
+            elif(hydrogen_bond_donor):
+                if(elem.text):
+                    compound_data["hydrogen_bond_donor_count"] = elem.text
+                hydrogen_bond_donor = False
+            elif(rotatable_bond):
+                if(elem.text):
+                    compound_data["rotatable_bond_count"] = elem.text
+                rotatable_bond = False
 
-                elif((elem.tag == "PC-Urn_name") & (event == 'start')):
-                    if(elem.text == 'Hydrogen Bond Acceptor'):
-                        hydrogen_bond_acceptor = True
-                    elif(elem.text == 'Hydrogen Bond Donor'):
-                        hydrogen_bond_donor = True
-                    elif(elem.text == 'Rotatable Bond'):
-                        rotatable_bond = True
-                    elif(iupac):
-                        iupac_key = elem.text
-                    elif(smiles):
-                        smiles_key = elem.text
+        elif((elem.tag == "PC-InfoData_value_fval") & (event == 'end')):
+            if(logp):
+                if(elem.text):
+                    compound_data["xlogp"] = elem.text
+                logp = False
+            elif(topological):
+                if(elem.text):
+                    compound_data["topological_polar_surface_area"] = elem.text
+                topological = False
+            elif(complexity):
+                if(elem.text):
+                    compound_data["complexity"] = elem.text
+                complexity = False
 
-                elif((elem.tag == "PC-InfoData_value_sval") & (event == 'start')):
-                    if(inchi):
-                        if(elem.text):
-                            compound_data["inchi"] = elem.text
-                        inchi = False
-                    elif(inchikey):
-                        if(elem.text):
-                            # override _id if inchikey exists
-                            current_compound["_id"] = elem.text
-                            compound_data["inchikey"] = elem.text
-                        inchikey = False
-                    elif(iupac):
-                        if(iupac_key):
-                            if(elem.text):
-                                compound_data['iupac'][iupac_key] = elem.text
-                        iupac = False
-                    elif(molecular_formula):
-                        if(elem.text):
-                            compound_data["molecular_formula"] = elem.text
-                        molecular_formula = False
-                    elif(smiles):
-                        if(smiles_key):
-                            if(elem.text):
-                                compound_data['smiles'][smiles_key] = elem.text
-                        smiles = False
 
-                elif((elem.tag == "PC-InfoData_value_ival") & (event == 'start')):
-                    if(hydrogen_bond_acceptor):
-                        if(elem.text):
-                            compound_data["hydrogen_bond_acceptor_count"] = elem.text
-                        hydrogen_bond_acceptor = False
-                    elif(hydrogen_bond_donor):
-                        if(elem.text):
-                            compound_data["hydrogen_bond_donor_count"] = elem.text
-                        hydrogen_bond_donor = False
-                    elif(rotatable_bond):
-                        if(elem.text):
-                            compound_data["rotatable_bond_count"] = elem.text
-                        rotatable_bond = False
+if __name__ == "__main__":
+    import json
+    import sys
 
-                elif((elem.tag == "PC-InfoData_value_fval") & (event == 'start')):
-                    if(logp):
-                        if(elem.text):
-                            compound_data["xlogp"] = elem.text
-                        logp = False
-                    elif(mass):
-                        if(elem.text):
-                            compound_data["exact_mass"] = elem.text
-                        mass = False
-                    elif(molecular_weight):
-                        if(elem.text):
-                            compound_data["molecular_weight"] = elem.text
-                        molecular_weight = False
-                    elif(topological):
-                        if(elem.text):
-                            compound_data["topological_polar_surface_area"] = elem.text
-                        topological = False
-                    elif(monoisotopic_weight):
-                        if(elem.text):
-                            compound_data["monoisotopic_weight"] = elem.text
-                        monoisotopic_weight = False
-                    elif(complexity):
-                        if(elem.text):
-                            compound_data["complexity"] = elem.text
-                        complexity = False
-            except Exception as e:
-                print(e)
-    except Exception as e:
-        print(e)
+    annotations = load_annotations(sys.argv[1])
+    for a in annotations:
+        print(json.dumps(a, indent=2))

--- a/src/hub/dataload/sources/pubchem/pubchem_parser.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_parser.py
@@ -96,6 +96,10 @@ def load_annotations(input_file):
             if(elem.text):
                 if((elem.tag == "PC-Count_heavy-atom") & (event == 'end')):
                     compound_data["heavy_atom_count"] = elem.text
+                elif((elem.tag == "PC-Count_atom-chiral") & (event == 'end')):
+                    compound_data["chiral_atom_count"] = elem.text
+                elif((elem.tag == "PC-Count_bond-chiral") & (event == 'end')):
+                    compound_data["chiral_bond_count"] = elem.text
                 elif((elem.tag == "PC-Count_atom-chiral-def") & (event == 'end')):
                     compound_data["defined_chiral_atom_count"] = elem.text
                 elif((elem.tag == "PC-Count_bond-chiral-def") & (event == 'end')):

--- a/src/hub/dataload/sources/pubchem/pubchem_parser.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_parser.py
@@ -70,6 +70,7 @@ def load_annotations(input_file):
                 if((elem.tag == "PC-CompoundType_id_cid") & (event == 'start')):
                     current_compound = {}
                     compound_data = {}
+                    # cid is _id, unless inchikey exists (overwritten below)
                     current_compound["_id"] = elem.text
                     compound_data["cid"] = elem.text
                     compound_data["iupac"] = {}
@@ -159,6 +160,8 @@ def load_annotations(input_file):
                         inchi = False
                     elif(inchikey):
                         if(elem.text):
+                            # override _id if inchikey exists
+                            current_compound["_id"] = elem.text
                             compound_data["inchikey"] = elem.text
                         inchikey = False
                     elif(iupac):
@@ -219,13 +222,3 @@ def load_annotations(input_file):
                 print(e)
     except Exception as e:
         print(e)
-
-
-if __name__ == "__main__":
-    import json
-
-    i = 0
-    while i < 3:
-        annotations = load_annotations("./data/Compound_024500001_025000000.xml.gz")
-        print(json.dumps(next(annotations), indent=2))
-        i += 1

--- a/src/hub/dataload/sources/pubchem/pubchem_upload.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_upload.py
@@ -136,6 +136,12 @@ class PubChemUploader(ParallelizedSourceUploader):
                     "heavy_atom_count": {
                         "type": "integer"
                     },
+                    "chiral_atom_count": {
+                        "type": "integer"
+                    },
+                    "chiral_bond_count": {
+                        "type": "integer"
+                    },
                     "defined_chiral_atom_count": {
                         "type": "integer"
                     },

--- a/src/hub/dataload/sources/pubchem/pubchem_upload.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_upload.py
@@ -53,7 +53,9 @@ class PubChemUploader(ParallelizedSourceUploader):
             "pubchem": {
                 "properties": {
                     "cid": {
-                        "type": "integer"
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword",
+                        'copy_to': ['all'],
                     },
                     "iupac": {
                         "properties": {
@@ -93,7 +95,7 @@ class PubChemUploader(ParallelizedSourceUploader):
                         "type": "integer"
                     },
                     "complexity": {
-                        "type": "integer"
+                        "type": "float"
                     },
                     "hydrogen_bond_acceptor_count": {
                         "type": "integer"

--- a/src/hub/dataload/sources/pubchem/pubchem_upload.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_upload.py
@@ -50,105 +50,111 @@ class PubChemUploader(ParallelizedSourceUploader):
     @classmethod
     def get_mapping(klass):
         return {
-                "pubchem" : {
-                    "properties" : {
-                        "inchi_key" : {
-                            "normalizer": "keyword_lowercase_normalizer",
-                            "type": "keyword",
+            "pubchem": {
+                "properties": {
+                    "cid": {
+                        "type": "integer"
+                    },
+                    "iupac": {
+                        "properties": {
+                            "allowed": {
+                                "type": "text"
                             },
-                        "undefined_atom_stereocenter_count" : {
-                            "type":"integer"
+                            "cas_like_style": {
+                                "type": "text"
                             },
-                        "formal_charge" : {
-                            "type":"integer"
+                            "markup": {
+                                "type": "text"
                             },
-                        "isotope_atom_count" : {
-                            "type":"integer"
+                            "preferred": {
+                                "type": "text"
                             },
-                        "defined_atom_stereocenter_count" : {
-                            "type":"integer"
+                            "systematic": {
+                                "type": "text"
                             },
-                        "molecular_weight" : {
-                            "type":"float"
-                            },
-                        "monoisotopic_weight" : {
-                            "type":"float"
-                            },
-                        "tautomers_count" : {
-                            "type":"integer"
-                            },
-                        "rotatable_bond_count" : {
-                            "type":"integer"
-                            },
-                        "exact_mass" : {
-                            "type":"float"
-                            },
-                        "chiral_bond_count" : {
-                            "type":"integer"
-                            },
-                        "smiles" : {
-                            "properties" : {
-                                "isomeric" : {
-                                    "normalizer": "keyword_lowercase_normalizer",
-                                    "type": "keyword",
-                                    },
-                                "canonical" : {
-                                    "normalizer": "keyword_lowercase_normalizer",
-                                    "type": "keyword",
-                                    }
-                                }
-                            },
-                        "hydrogen_bond_acceptor_count" : {
-                            "type":"integer"
-                            },
-                        "hydrogen_bond_donor_count" : {
-                                "type":"integer"
-                                },
-                        "inchi" : {
-                                "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                },
-                        "undefined_bond_stereocenter_count" : {
-                                "type":"integer"
-                                },
-                        "defined_bond_stereocenter_count" : {
-                                "type":"integer"
-                                },
-                        "xlogp" : {
-                                "type":"float"
-                                },
-                        "chiral_atom_count" : {
-                                "type":"integer"
-                                },
-                        "cid" : {
-                                "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                'copy_to': ['all'],
-                                },
-                        "topological_polar_surface_area" : {
-                                "type":"float"
-                                },
-                        "iupac" : {
-                                "properties" : {
-                                    "traditional" : {
-                                        "type":"text"
-                                        }
-                                    }
-                                },
-                        "complexity" : {
-                                "type":"float"
-                                },
-                        "heavy_atom_count" : {
-                                "type":"integer"
-                                },
-                        "molecular_formula" : {
-                                "normalizer": "keyword_lowercase_normalizer",
-                                "type": "keyword",
-                                },
-                        "covalently-bonded_unit_count" : {
-                                "type":"integer"
-                                }
+                            "traditional": {
+                                "type": "text"
+                            }
                         }
+                    },
+                    "smiles": {
+                        "properties": {
+                            "canonical": {
+                                "normalizer": "keyword_lowercase_normalizer",
+                                "type": "keyword"
+                            },
+                            "isomeric": {
+                                "normalizer": "keyword_lowercase_normalizer",
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "formal_charge": {
+                        "type": "integer"
+                    },
+                    "complexity": {
+                        "type": "integer"
+                    },
+                    "hydrogen_bond_acceptor_count": {
+                        "type": "integer"
+                    },
+                    "hydrogen_bond_donor_count": {
+                        "type": "integer"
+                    },
+                    "rotatable_bond_count": {
+                        "type": "integer"
+                    },
+                    "inchi": {
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword"
+                    },
+                    "inchikey": {
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword"
+                    },
+                    "xlogp": {
+                        "type": "float"
+                    },
+                    "exact_mass": {
+                        "type": "float"
+                    },
+                    "molecular_formula": {
+                        "normalizer": "keyword_lowercase_normalizer",
+                        "type": "keyword"
+                    },
+                    "molecular_weight": {
+                        "type": "float"
+                    },
+                    "topological_polar_surface_area": {
+                        "type": "float"
+                    },
+                    "monoisotopic_weight": {
+                        "type": "float"
+                    },
+                    "heavy_atom_count": {
+                        "type": "integer"
+                    },
+                    "defined_chiral_atom_count": {
+                        "type": "integer"
+                    },
+                    "undefined_chiral_atom_count": {
+                        "type": "integer"
+                    },
+                    "defined_chiral_bond_count": {
+                        "type": "integer"
+                    },
+                    "undefined_chiral_bond_count": {
+                        "type": "integer"
+                    },
+                    "isotope_atom_count": {
+                        "type": "integer"
+                    },
+                    "covalent_unit_count": {
+                        "type": "integer"
+                    },
+                    "tautomers_count": {
+                        "type": "integer"
+                    }
                 }
             }
-
+        }


### PR DESCRIPTION
This PR fixes several bugs with the Pubchem parser:

1. Uses inchikey as primary _id, instead of cid
2. Updates the storage class to storage.RootKeyMergerStorage to combine duplicate documents that have the same inchikey.
3. Fixes type issues with several numeric values which were being parsed as strings. (937ee5c)
4. Fixes issues with missing keys and documents due to incomplete XML parsing  (1f37394)
5. Fix parsing issues with molecular weight values, with were not searching for the right XML field.
6. Adds automatic indexing to pubchem.cid and pubchem.inchi fields in pubchem_upload.py.
7. Update the hard-coded mapping