### PR TITLE
Update unii plugin

### DIFF
--- a/src/hub/dataload/sources/unii/unii_dump.py
+++ b/src/hub/dataload/sources/unii/unii_dump.py
@@ -1,11 +1,11 @@
-import os, sys, re, time
+import datetime
+import os
+
 import bs4
 import dateutil.parser as dtparser
-import datetime
-
-from config import DATA_ARCHIVE_ROOT
-from biothings.hub.dataload.dumper import HTTPDumper, DumperException
+from biothings.hub.dataload.dumper import DumperException, HTTPDumper
 from biothings.utils.common import unzipall
+from config import DATA_ARCHIVE_ROOT
 
 
 class UniiDumper(HTTPDumper):
@@ -14,28 +14,34 @@ class UniiDumper(HTTPDumper):
     SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
 
     SCHEDULE = "0 12 * * *"
-    HOMEPAGE_URL = "https://fdasis.nlm.nih.gov/srs"
-    DATA_URL = "https://fdasis.nlm.nih.gov/srs/download/srs/UNII_Data.zip"
+    HOMEPAGE_URL = "https://precision.fda.gov/uniisearch/archive"
+    DATA_BASE_URL = "https://qnyqxh695c.execute-api.us-east-1.amazonaws.com/production/v1/get-file/"
 
     def get_latest_release(self):
         res = self.client.get(self.__class__.HOMEPAGE_URL)
-        html = bs4.BeautifulSoup(res.text,"lxml")
-        # link containing the latest date version
-        version = html.find(attrs={"href":"/srs/jsp/srs/uniiListDownload.jsp"}).text
-        m = re.match("UNII List download \(updated (.*)\)",version)
+        # Raise error if status is not 200
+        res.raise_for_status()
+        # Parse the html for the text in the first 'div' element under the archive accordion
+        html = bs4.BeautifulSoup(res.text, 'lxml')
+        archive = html.find("div", attrs={"class": "usa-accordion__content usa-prose"})
+        version = archive.find("div", attrs={"class": "styles__StyledDownloadLink-sc-pyispm-6 cdoIOb"}).text
         try:
-            latest = datetime.date.strftime(dtparser.parse(m.groups()[0]),"%Y-%m-%d")
+            latest = datetime.date.strftime(dtparser.parse(version), "%Y-%m-%d")
             return latest
         except Exception as e:
-            raise DumperException("Can't find or parse date from URL '%s': %s" % (self.__class__.HOMEPAGE_URL,e))
+            raise DumperException("Can't find or parse date from URL '%s': %s" % (self.__class__.HOMEPAGE_URL, e))
 
-    def create_todump_list(self,force=False,**kwargs):
+    def create_todump_list(self, force=False, **kwargs):
         self.release = self.get_latest_release()
-        if force or not self.src_doc or (self.src_doc and self.src_doc.get("download",{}).get("release") < self.release):
-            # if new release, that link points to that latest release
-            local = os.path.join(self.new_data_folder,os.path.basename(self.DATA_URL))
-            self.to_dump.append({"remote":self.DATA_URL, "local":local})
+        if force or not self.src_doc or (self.src_doc and self.src_doc.get("download", {}).get("release") < self.release):
+            # if new release, generate link that points to that latest release
+            res = self.client.get(
+                self.__class__.DATA_BASE_URL + "{}/UNII_Data_{}.zip".format(self.release, self.release.replace("-", ""))
+                )
+            res.raise_for_status()
+            data_url = res.json()['url']
+            local = os.path.join(self.new_data_folder, self.release)
+            self.to_dump.append({"remote": data_url, "local": local})
 
     def post_dump(self, *args, **kwargs):
         unzipall(self.new_data_folder)
-

--- a/src/hub/dataload/sources/unii/unii_parser.py
+++ b/src/hub/dataload/sources/unii/unii_parser.py
@@ -1,6 +1,4 @@
 import pandas as pd
-import json
-
 from biothings.utils.dataload import int_convert
 
 
@@ -18,12 +16,12 @@ def load_data(input_file):
     unii['_id'].fillna(unii.unii, inplace=True)
 
     dupes = set(unii._id) - set(unii._id.drop_duplicates(False))
-    records = [{k:v for k,v in record.items() if pd.notnull(v)} for record in unii.to_dict("records") if record['_id'] not in dupes]
+    records = [{k: v for k, v in record.items() if pd.notnull(v)} for record in unii.to_dict("records") if record['_id'] not in dupes]
     records = [{'_id': record['_id'], 'unii': record} for record in records]
     # take care of a couple cases with identical inchikeys
     for dupe in dupes:
         dr = unii.query("_id == @dupe").to_dict("records")
-        dr = [{k:v for k,v in record.items() if pd.notnull(v)} for record in dr]
+        dr = [{k: v for k, v in record.items() if pd.notnull(v)} for record in dr]
         records.append({'_id': dupe, 'unii': dr})
     for record in records:
         if isinstance(record['unii'], dict):
@@ -37,3 +35,24 @@ def load_data(input_file):
 
         yield record
 
+
+if __name__ == "__main__":
+    """For standalone debugging"""
+
+    from glob import glob
+    import json
+    import sys
+
+    # Add config directory to path
+    sys.path.append("../../../../")
+
+    from unii_dump import UniiDumper
+
+    dumper = UniiDumper()
+    dumper.get_latest_release()
+    dumper.create_todump_list()
+
+    input_file = glob(dumper.new_data_folder + "/*Records*.txt")[0]
+
+    for rec in load_data(input_file):
+        print(json.dumps(rec, indent=2))

--- a/src/hub/dataload/sources/unii/unii_upload.py
+++ b/src/hub/dataload/sources/unii/unii_upload.py
@@ -10,9 +10,9 @@ from hub.datatransform.keylookup import MyChemKeyLookup
 
 
 SRC_META = {
-        "url": 'https://fdasis.nlm.nih.gov/srs/',
+        "url": 'https://precision.fda.gov/uniisearch',
         "license": "public domain",
-        "license_url" : "https://www.nlm.nih.gov/copyright.html",
+        "license_url" : "https://www.nlm.nih.gov/web_policies.html",
         "license_url_short": "http://bit.ly/2Pg8Oo9"
         }
 

--- a/src/hub/dataload/sources/unii/unii_upload.py
+++ b/src/hub/dataload/sources/unii/unii_upload.py
@@ -107,7 +107,7 @@ class UniiUploader(BaseDrugUploader):
                                 "normalizer": "keyword_lowercase_normalizer",
                                 "type": "keyword",
                                 },
-                        "unii_type": {
+                        "ingredient_type": {
                                 "type": "text"
                                 },
                         "pubchem": {


### PR DESCRIPTION
Fixes #128:

1. Modify the dumper to scrape the new UNII website (https://precision.fda.gov/uniisearch) for the release date, and download the appropriate file.
2. Update the mapping to replace a field that was renamed in the original data.
2. Allow the parser to be executed as a standalone module for easier debugging.

**Changes to data fields:**
`unii.unii_type` was renamed to `unii.ingredient_type`