### PR TITLE
130 update umls plugin

### DIFF
--- a/src/config_web.py
+++ b/src/config_web.py
@@ -27,6 +27,8 @@ ANNOTATION_ID_REGEX_LIST = [
     (re.compile(r'chembl[0-9]+', re.I), 'chembl.molecule_chembl_id'),
     (re.compile(r'chebi\:[0-9]+', re.I), ['chebi.id', 'chebi.secondary_chebi_id']),
     (re.compile(r'[A-Z0-9]{10}'), 'unii.unii'),
+    (re.compile(r'db[0-9]+', re.I), ['unichem.drugbank', 'chebi.xrefs.drugbank', 'drugcentral.xrefs.drugbank_id', 'pharmgkb.xrefs.drugbank']),
+    (re.compile(r'pa[0-9]+', re.I), 'pharmgkb.id'),
     (re.compile(r'((cid\:(?P<term>[0-9]+))|([0-9]+))', re.I), ['pubchem.cid', 'fda_orphan_drug.pubchem_sid'])
 ]
 

--- a/src/config_web.py
+++ b/src/config_web.py
@@ -22,8 +22,6 @@ ES_SCROLL_TIME = '10m'
 # *****************************************************************************
 
 ANNOTATION_ID_REGEX_LIST = [
-    # Drugbank datasource was removed in 0.10.x
-    # (re.compile(r'db[0-9]+', re.I), 'drugbank.id'),
     (re.compile(r'chembl[0-9]+', re.I), 'chembl.molecule_chembl_id'),
     (re.compile(r'chebi\:[0-9]+', re.I), ['chebi.id', 'chebi.secondary_chebi_id']),
     (re.compile(r'[A-Z0-9]{10}'), 'unii.unii'),

--- a/src/hub/dataload/sources/umls/umls_dump.py
+++ b/src/hub/dataload/sources/umls/umls_dump.py
@@ -1,31 +1,50 @@
+import datetime
 import os
-import os.path
-import sys
-import time
 
-import biothings, config
-biothings.config_for_app(config)
-
-from config import DATA_ARCHIVE_ROOT
-from biothings.hub.dataload.dumper import ManualDumper
+import bs4
+import dateutil.parser as dtparser
+from biothings.hub.dataload.dumper import DumperException, HTTPDumper
 from biothings.utils.common import unzipall
+from config import DATA_ARCHIVE_ROOT
 
 
-class UMLSDumper(ManualDumper):
+class UMLSDumper(HTTPDumper):
 
     SRC_NAME = "umls"
     SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
-    #VERSION = '2020-4-7'
 
-    #def __init__(self, *args, **kwargs):
-    #    super(UMLSDumper,self).__init__(*args,**kwargs)
-    #    self.logger.info("""Manu#ally download from: https://download.nlm.nih.gov/umls/kss/2019AB/umls-2019AB-mrconso.zip""")
+    SCHEDULE = "0 12 * * *"
+    HOMEPAGE_URL = "https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html"
 
-    #def create_todump_list(self, force=True):
-    #    self.release = VERSION
-    #    local = os.path.join(SRC_ROOT_FOLDER, VERSION)
-    #    self.to_dump.append({"remote":VERSION, "local":local})
+    def get_latest_release(self):
+        res = self.client.get(self.__class__.HOMEPAGE_URL)
+        # Raise error if status is not 200
+        res.raise_for_status()
+        html = bs4.BeautifulSoup(res.text, 'lxml')
+        # Get the table of metathesaurus release files
+        table = html.find("table", attrs={"class": "mb-4"})
+        rows = table.find_all('tr')
+        # The header of the fifth column should be 'Date'
+        assert rows[0].find_all('th')[4].text == 'Date', "Could not parse version from html table."
+        version = rows[1].find_all('td')[4].text
+        try:
+            latest = datetime.date.strftime(dtparser.parse(version), "%Y-%m-%d")
+            return latest
+        except Exception as e:
+            raise DumperException("Can't find or parse date from table field {}: {}" % (version, e))
 
-    #def post_dump(self, *args, **kwargs):
-    #    self.logger.info("Unzipping files in '%s'" % self.new_data_folder) 
-    #    unzipall(self.new_data_folder)
+    def create_todump_list(self, force=True):
+        self.release = self.get_latest_release()
+        if force or not self.src_doc or (self.src_doc and self.src_doc.get("download", {}).get("release") < self.release):
+            self.logger.info("Manually download from: https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html")
+            # Create data folder
+            local = os.path.join(self.SRC_ROOT_FOLDER, self.release)
+            if not os.path.exists(local):
+                os.makedirs(local)
+            # Dump a dummy file, to mark dump as successful and trigger uploader
+            release_notes = "https://www.nlm.nih.gov/research/umls/knowledge_sources/metathesaurus/release/notes.html"
+            self.to_dump.append({"remote":release_notes, "local":os.path.join(local, "release_notes.html")})
+
+    def post_dump(self, *args, **kwargs):
+        self.logger.info("Unzipping files in '%s'" % self.new_data_folder)
+        unzipall(self.new_data_folder)

--- a/src/hub/dataload/sources/umls/umls_parser.py
+++ b/src/hub/dataload/sources/umls/umls_parser.py
@@ -1,8 +1,8 @@
-from collections import defaultdict
-from biothings_client import get_client
 import os
-import copy
 import time
+from collections import defaultdict
+
+from biothings_client import get_client
 
 CHEM_CLIENT = get_client('chem')
 # list of UMLS semantic types belonging to chemical is based on
@@ -124,6 +124,15 @@ def unlist(l):
 def load_data(data_folder):
     mrsat_file = os.path.join(data_folder, 'MRSTY.RRF')
     mrconso_file = os.path.join(data_folder, 'MRCONSO.RRF')
+    if not os.path.exists(mrsat_file):
+        raise FileNotFoundError(
+            """Could not find 'MRSTY.RRF' in {}.
+            Please download UMLS Metathesaurus files manually and extract to folder.
+            """.format(data_folder))
+    if not os.path.exists(mrconso_file):
+        raise FileNotFoundError(
+            """Could not find 'MRCONSO.RRF' in {}.
+            Please download manually and extract to folder.""".format(data_folder))
     chem_umls = fetch_chemical_umls_cuis(mrsat_file)
     cui_map, mesh_ids, names = parse_umls(mrconso_file, chem_umls)
     name_mapping = query_drug_name(names)
@@ -169,3 +178,20 @@ def load_data(data_folder):
                 })
                 id_set.add(cui)
     return res
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    # Add config directory to path
+    sys.path.append("../../../../")
+
+    from umls_dump import UMLSDumper
+
+    dumper = UMLSDumper()
+    dumper.get_latest_release()
+    dumper.create_todump_list()
+
+    for rec in load_data(dumper.new_data_folder):
+        print(json.dumps(rec, indent=2))


### PR DESCRIPTION
UMLS dumper now gets the latest release version from "https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html", however, it still requires for the mantainer  to manually download the relevant files, as they are behind a login wall.