### PR TITLE
Search chembl.molecule_chembl_id by default

### DIFF
--- a/src/hub/dataload/sources/chembl/chembl_upload.py
+++ b/src/hub/dataload/sources/chembl/chembl_upload.py
@@ -259,7 +259,10 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
                     },
                     "molecule_chembl_id": {
                         "normalizer": "keyword_lowercase_normalizer",
-                        "type": "keyword"
+                        "type": "keyword",
+                        "copy_to": [
+                            "all"
+                        ]
                     },
                     "molecule_properties": {
                         "properties": {


### PR DESCRIPTION
Fix for chembl issues in #11. 