### PR TITLE
Catch UnicodeDecodeError and retry

### DIFF
--- a/src/hub/dataload/sources/unii/unii_parser.py
+++ b/src/hub/dataload/sources/unii/unii_parser.py
@@ -3,8 +3,11 @@ from biothings.utils.dataload import int_convert
 
 
 def load_data(input_file):
-
-    unii = pd.read_csv(input_file, sep='\t', low_memory=False, dtype=str)
+    try:
+        unii = pd.read_csv(input_file, sep='\t', low_memory=False, dtype=str)
+    except UnicodeDecodeError:
+        unii = pd.read_csv(input_file, sep='\t', low_memory=False, dtype=str, encoding='windows-1252')
+    
     unii.rename(columns={'MF': 'molecular_formula',
                          'PT': 'preferred_term',
                          'RN': 'registry_number'}, inplace=True)


### PR DESCRIPTION
In the latest release of UNII, the `*Records*.txt` file was encoded as 'windows-1252' instead of utf8.
Not sure if future releases will be the same, so I'm catching the error and retrying with the new encoding.