### PR TITLE
Improvements to Pubchem dumper and parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/bin/ssh_host*
 src/biothings/
 
 src/.idea
+*.crt
 
 # Emacs
 *~

--- a/src/hub/dataload/sources/pubchem/pubchem_dump.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_dump.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 
 import biothings
-from pytest import fail
 import config
 biothings.config_for_app(config)
 

--- a/src/hub/dataload/sources/pubchem/pubchem_dump.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_dump.py
@@ -46,7 +46,7 @@ class PubChemDumper(FTPDumper):
 
     def create_todump_list(self, force=False):
         self.get_release()
-        failed_list = os.join(self.new_data_folder, "failed_dump.list")
+        failed_list = os.path.join(self.new_data_folder, "failed_dump.list")
         if self.new_release_available():
             # It's a new release, so make sure we remove failed file list and dump all.
             if os.path.exists(failed_list):
@@ -113,8 +113,10 @@ class PubChemDumper(FTPDumper):
             old = os.path.abspath(os.curdir)
             os.chdir(self.new_data_folder)
             try:
-                if os.path.exists(os.join(self.new_data_folder, "failed_dump.list")):
-                    with open(os.join(self.new_data_folder, "failed_dump.list"), 'r') as f:
+                failed_list = os.path.join(self.new_data_folder, "failed_dump.list")
+                if os.path.exists(failed_list):
+                    # If we have a failed dump list, only check md5sum of files that failed
+                    with open(failed_list, 'r') as f:
                         md5_files = f.read().splitlines()
                 else:
                     md5_files = glob.glob("*.md5")
@@ -133,7 +135,7 @@ class PubChemDumper(FTPDumper):
                             len(failed_files),
                             '\n'.join(["\t" + fn for fn in failed_files[:10]])    # only display top 10 if it's a long list
                         )
-                        with open(os.join(self.new_data_folder, "failed_dump.list"), 'w') as f:
+                        with open(failed_list, 'w') as f:
                             f.write('\n'.join(os.path.basename(failed_files)))
                         raise DumperException(err_msg)
                     else:

--- a/src/hub/dataload/sources/pubchem/pubchem_parser.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_parser.py
@@ -89,7 +89,7 @@ def parse_one_file(input_file):
         elif((elem.tag == "PC-Compound") & (event == 'end')):
             # Document parsing is complete
             current_compound["pubchem"] = compound_data
-            # Fall through to using cid if inchikey is not present
+            # Fall back to using cid if inchikey is not present
             if current_compound.get("_id") is None:
                 current_compound["_id"] = current_compound["pubchem"]["cid"]
             # This shouldn't happen, but just in case

--- a/src/hub/dataload/sources/pubchem/pubchem_parser.py
+++ b/src/hub/dataload/sources/pubchem/pubchem_parser.py
@@ -89,6 +89,10 @@ def parse_one_file(input_file):
         elif((elem.tag == "PC-Compound") & (event == 'end')):
             # Document parsing is complete
             current_compound["pubchem"] = compound_data
+            # Fall through to using cid if inchikey is not present
+            if current_compound.get("_id") is None:
+                current_compound["_id"] = current_compound["pubchem"]["cid"]
+            # This shouldn't happen, but just in case
             assert current_compound.get("_id"), "File {}, document {} is missing an _id".format(input_file, current_compound)
             # Convert numeric values to float or integer
             current_compound = value_convert_to_number(current_compound, skipped_keys=["_id", "pubchem.cid"])


### PR DESCRIPTION
### Dumper fixes:
**Resume download for failed md5sum checks.**
Outputs the list of failed md5 files to a file: `failed_dump.list`. After manual re-dump, dumper checks for existence of this file, and only dumps and checks md5 hashes for the files in this list. If dump is successful, or if a new version of Pubchem is released, `failed_dump.list` is deleted from disk and a full dump is executed.

### Parser fixes:
Fall back to using `pubchem.cid` for `_id` if there is no inchikey in document. This is a very rare occurrence, but the latest Pubchem release had at least one document without inchikey.