### PR TITLE
Upgrade to biothings 0.11.1, remove dotstring pkg

### DIFF
--- a/requirements_web.txt
+++ b/requirements_web.txt
@@ -1,1 +1,1 @@
-git+https://github.com/biothings/biothings.api@0.11.1#egg=biothings[web_extra]
+git+https://github.com/biothings/biothings.api#egg=biothings[web_extra]==0.11.1

--- a/requirements_web.txt
+++ b/requirements_web.txt
@@ -1,4 +1,1 @@
-git+https://github.com/biothings/biothings.api#egg=biothings[web_extra]
-
-# for dotstring utilities
-git+https://github.com/greg-k-taylor/dotstring.git@v0.1.2#egg=dotstring
+git+https://github.com/biothings/biothings.api@0.11.x#egg=biothings[web_extra]

--- a/requirements_web.txt
+++ b/requirements_web.txt
@@ -1,1 +1,1 @@
-git+https://github.com/biothings/biothings.api@0.11.x#egg=biothings[web_extra]
+git+https://github.com/biothings/biothings.api@0.11.1#egg=biothings[web_extra]


### PR DESCRIPTION

Update biothings web component to `0.11.1`
Remove `dotstring` package requirement, which was integrated in biothings after https://github.com/biothings/mychem.info/commit/c3bdd8d