### PR TITLE
Follow-up to PR#154

### DIFF
--- a/src/hub/dataload/sources/chembl/chembl_upload.py
+++ b/src/hub/dataload/sources/chembl/chembl_upload.py
@@ -52,8 +52,6 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
         """
         molecule_filepaths = glob.glob(os.path.join(self.data_folder, self.MOLECULE_FILENAME_PATTERN))
         mol_data_loaders = [MoleculeDataLoader(molecule_filepath=filepath) for filepath in molecule_filepaths]
-        for mol_data_loader in mol_data_loaders:
-            mol_data_loader.load()
 
         drug_indication_filepaths = glob.iglob(os.path.join(self.data_folder, self.DRUG_INDICATION_FILENAME_PATTERN))
         mechanism_filepaths = glob.iglob(os.path.join(self.data_folder, self.MECHANISM_FILENAME_PATTERN))
@@ -63,7 +61,7 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
                                               mechanism_filepaths=mechanism_filepaths,
                                               target_filepaths=target_filepaths,
                                               binding_site_filepaths=binding_site_filepaths)
-        aux_data_loader.load()
+        aux_data_loader.eagerly_load()
 
         return [(mol_data_loader, aux_data_loader) for mol_data_loader in mol_data_loaders]
 
@@ -212,6 +210,18 @@ class ChemblUploader(BaseDrugUploader, ParallelizedSourceUploader):
                             },
                             "target_chembl_id": {
                                 "type": "keyword"
+                            },
+                            "target_components": {
+                                "properties": {
+                                    "uniprot": {
+                                        "normalizer": "keyword_lowercase_normalizer",
+                                        "type": "keyword"
+                                    },
+                                    "ensembl_gene": {
+                                        "normalizer": "keyword_lowercase_normalizer",
+                                        "type": "keyword"
+                                    }
+                                }
                             },
                             "target_name": {
                                 "type": "text"


### PR DESCRIPTION
This PR is a follow-up to PR https://github.com/biothings/mychem.info/pull/154:

## 1. Bug Fix

This PR fixes a bug that `AuxiliaryDataLoader` objects cannot be pickled.

The pickling is started by [`JobManager`](https://github.com/biothings/biothings.api/blob/master/biothings/utils/manager.py#L477). The call stack is like:

```python
JobManager.defer_to_process()  # manager.py#L785 
    => run()                   # manager.py#L786 
        => do_work()           # manager.py#L814 & #113 
             => @track         # manager.py#L28 
```

Therefore both `AuxiliaryDataLoader` and `MoleculeDataLoader` objects, as arguments of `load_chembl_data`, will be pickled.

Previously `AuxiliaryDataLoader` holded `glob.iglob` objects as its file path members, but `glob.iglob` are generators and cannot be pickled. In this PR, `glob.iglob` generators are forced into lists and problem solved.

In addition, some members are removed from `AuxiliaryDataLoader` and `MoleculeDataLoader` to reduce the overhead of pickling.

## 2. File Loading Optimization

This PR optimizes the file loading policy, considering the multi-process environment:

1. There is only one `AuxiliaryDataLoader` object, who is shared among all the uploading processes. It should be eagerly loaded in the main process. (It's a waste of time to load it repeatedly in sub processes.)
2. There are multiple `MoleculeDataLoader` objects, one for each uploading processes. It should be lazily loaded within each sub process. (It's not efficient to load all of them in the main process, unparalleledly.)

## 3. ES Mapping

This PR adds ES mapping for the new `target_components` field.