### PR TITLE
Make NDC product names searchable by default

### DIFF
--- a/src/hub/dataload/sources/ndc/ndc_upload.py
+++ b/src/hub/dataload/sources/ndc/ndc_upload.py
@@ -57,7 +57,7 @@ class NDCUploader(BaseDrugUploader):
                     "proprietaryname": {
                         "normalizer": "keyword_lowercase_normalizer",
                         "type": "keyword",
-                        "copy_to": ["name"]
+                        "copy_to": ["all", "name"]
                     },
                     "proprietarynamesuffix": {
                         "normalizer": "keyword_lowercase_normalizer",
@@ -66,7 +66,7 @@ class NDCUploader(BaseDrugUploader):
                     "nonproprietaryname": {
                         "normalizer": "keyword_lowercase_normalizer",
                         "type": "keyword",
-                        "copy_to": ["name"]
+                        "copy_to": ["all", "name"]
                     },
                     "dosageformname": {
                         "normalizer": "keyword_lowercase_normalizer",


### PR DESCRIPTION
## Summary

Copy NDC proprietary and nonproprietary names directly to both the `all` and `name` aggregate fields.

## Root cause and impact

Elasticsearch does not chain `copy_to`. Values copied only into `name` never reached `all`, which is the field used by default free-text queries. Brand names such as TORPENZ were indexed but unavailable to ordinary `?q=` searches.

A reindex is required for the mapping change to affect existing documents.

## Validation

- staged diff validation
- Python compilation

Closes #197