### PR TITLE
Fix merged-record name ranking

### DIFF
--- a/src/hub/dataindex/indexer.py
+++ b/src/hub/dataindex/indexer.py
@@ -4,9 +4,10 @@ from biothings.hub.dataindex.indexer import Indexer
 
 DEFAULT_INDEX_MAPPINGS = {
     "properties": {
-        "all": {"type": "text"},
+        "all": {"type": "text", "norms": False},
         "name": {
             "type": "text",
+            "norms": False,
             "fields": {
                 "raw": {
                     "type": "keyword",


### PR DESCRIPTION
## Summary

Disable field-length norms on the aggregate `all` and `name` text fields.

## Root cause and impact

BM25 length normalization penalized well-merged chemical records because they contain many curated names and synonyms. Sparse NDC or UMLS records could therefore outrank the canonical compound for its own name. Disabling norms removes that counterproductive length penalty while preserving text matching.

A reindex is required for the mapping change to affect existing documents.

## Validation

- staged diff validation
- Python compilation
- mapping assertion for both norm settings

Closes #198