### PR TITLE
Prefer primary DrugBank IDs during annotation lookup

### DIFF
--- a/src/config_web.py
+++ b/src/config_web.py
@@ -143,3 +143,4 @@ ANNOTATION_KWARGS["*"].update(_extra_kwargs)
 QUERY_KWARGS = copy.deepcopy(QUERY_KWARGS)
 QUERY_KWARGS["*"].update(_extra_kwargs)
 ES_RESULT_TRANSFORM = "web.pipeline.MyChemESResultFormatter"
+ES_QUERY_PIPELINE = "web.pipeline.MyChemESQueryPipeline"

--- a/src/config_web.py
+++ b/src/config_web.py
@@ -24,6 +24,14 @@ ES_SCROLL_TIME = "10m"
 # Endpoint Specifics
 # *****************************************************************************
 
+DRUGBANK_ID_FIELDS = [
+    "drugbank.id",
+    "unichem.drugbank",
+    "chebi.xrefs.drugbank",
+    "drugcentral.xrefs.drugbank_id",
+    "pharmgkb.xrefs.drugbank",
+]
+
 # *** NOTE ***
 # The CHEBI prefix must have a regex_term_pattern without a named <term> grouping.
 # example query: CHEBI:57966:
@@ -58,6 +66,11 @@ BIOLINK_MODEL_PREFIX_BIOTHINGS_CHEM_MAPPING = {
         "field": "unii.unii",
         "regex_term_pattern": "(?P<term>[A-Z0-9]{10})",
     },
+    "DRUGBANK": {
+        "type": "chem",
+        "field": DRUGBANK_ID_FIELDS,
+        "regex_term_pattern": "(?P<term>DB[0-9]+)",
+    },
 }
 
 # CURIE ID support based on BioLink Model
@@ -87,12 +100,7 @@ chem_prefix_handling = [
     (re.compile(r"((unii\:(?P<term>[A-Z0-9]{10}))|([A-Z0-9]{10}))", re.I), "unii.unii"),
     (
         re.compile(r"((drugbank\:(?P<term>db[0-9]+))|(db[0-9]+))", re.I),
-        [
-            "unichem.drugbank",
-            "chebi.xrefs.drugbank",
-            "drugcentral.xrefs.drugbank_id",
-            "pharmgkb.xrefs.drugbank",
-        ],
+        DRUGBANK_ID_FIELDS,
     ),
     (
         re.compile(r"((pharmgkb.drug\:(?P<term>pa[0-9]+))|(pa[0-9]+))", re.I),

--- a/src/tests/test_data/TestAnnotationRegexMock/mychem_test.ndjson
+++ b/src/tests/test_data/TestAnnotationRegexMock/mychem_test.ndjson
@@ -4,3 +4,5 @@
 {"unichem": {"drugbank": "DB01590"}}
 {"index": {"_id": "CURATED"}}
 {"drugbank": {"id": "DB01590", "name": "Everolimus"}, "unichem": {"drugbank": "DB01590"}}
+{"index": {"_id": "XREF_ONLY"}}
+{"unichem": {"drugbank": "DB00001"}}

--- a/src/tests/test_data/TestAnnotationRegexMock/mychem_test.ndjson
+++ b/src/tests/test_data/TestAnnotationRegexMock/mychem_test.ndjson
@@ -1,2 +1,6 @@
 {"index": {"_id": "DEFAULTSCO"}}
 {"drugbank": {"name": "mock item should not be hit"}}
+{"index": {"_id": "SPARSE"}}
+{"unichem": {"drugbank": "DB01590"}}
+{"index": {"_id": "CURATED"}}
+{"drugbank": {"id": "DB01590", "name": "Everolimus"}, "unichem": {"drugbank": "DB01590"}}

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -125,4 +125,4 @@ class TestMyChemWebAppConfigAnnotationRegexMockData(BiothingsWebAppTest):
             ("DB01590", "CURATED"),
             ("DRUGBANK:DB01590", "CURATED"),
             ("DB00001", "XREF_ONLY"),
-        ]
+        ], res

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -110,3 +110,19 @@ class TestMyChemWebAppConfigAnnotationRegexMockData(BiothingsWebAppTest):
         res = self.request("chem/DRUGBANK:DB01590", method="GET").json()
         assert res["_id"] == "CURATED"
         assert res["drugbank"]["id"] == "DB01590"
+
+    def test_004_drugbank_crossref_fallback_is_preserved(self):
+        res = self.request("chem/DB00001", method="GET").json()
+        assert res["_id"] == "XREF_ONLY"
+
+    def test_005_drugbank_batch_prefers_primary_and_preserves_fallback(self):
+        res = self.request(
+            "chem",
+            method="POST",
+            data={"ids": ["DB01590", "DRUGBANK:DB01590", "DB00001"]},
+        ).json()
+        assert [(document["query"], document["_id"]) for document in res] == [
+            ("DB01590", "CURATED"),
+            ("DRUGBANK:DB01590", "CURATED"),
+            ("DB00001", "XREF_ONLY"),
+        ]

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -119,7 +119,7 @@ class TestMyChemWebAppConfigAnnotationRegexMockData(BiothingsWebAppTest):
         res = self.request(
             "chem",
             method="POST",
-            data={"ids": ["DB01590", "DRUGBANK:DB01590", "DB00001"]},
+            data={"ids": "DB01590,DRUGBANK:DB01590,DB00001"},
         ).json()
         assert [(document["query"], document["_id"]) for document in res] == [
             ("DB01590", "CURATED"),

--- a/src/tests/test_local.py
+++ b/src/tests/test_local.py
@@ -100,3 +100,13 @@ class TestMyChemWebAppConfigAnnotationRegexMockData(BiothingsWebAppTest):
         q = "DEFAULTSCO"
         # FIXME: check response status code
         res = self.request(f"chem/{q}", method="GET", expect=404)
+
+    def test_002_drugbank_primary_id_precedes_crossrefs(self):
+        res = self.request("chem/DB01590", method="GET").json()
+        assert res["_id"] == "CURATED"
+        assert res["drugbank"]["id"] == "DB01590"
+
+    def test_003_drugbank_curie_uses_primary_id(self):
+        res = self.request("chem/DRUGBANK:DB01590", method="GET").json()
+        assert res["_id"] == "CURATED"
+        assert res["drugbank"]["id"] == "DB01590"

--- a/src/web/pipeline.py
+++ b/src/web/pipeline.py
@@ -1,5 +1,82 @@
+import re
+
 from biothings.web.query.formatter import ESResultFormatter
+from biothings.web.query.pipeline import AsyncESQueryPipeline
 from biothings.web.options import OptionError
+
+
+DRUGBANK_ID_PATTERN = re.compile(r"(?:drugbank:)?(?P<term>db[0-9]+)", re.I)
+
+
+def _drugbank_id(value):
+    if not isinstance(value, str):
+        return None
+    match = DRUGBANK_ID_PATTERN.fullmatch(value)
+    return match.group("term").upper() if match else None
+
+
+def _field_values(value, path):
+    if not path:
+        if isinstance(value, list):
+            for item in value:
+                yield from _field_values(item, ())
+        elif value is not None:
+            yield value
+        return
+
+    if isinstance(value, list):
+        for item in value:
+            yield from _field_values(item, path)
+    elif isinstance(value, dict) and path[0] in value:
+        yield from _field_values(value[path[0]], path[1:])
+
+
+def _has_primary_drugbank_id(document, identifier):
+    return any(
+        str(value).upper() == identifier
+        for value in _field_values(document, ("drugbank", "id"))
+    )
+
+
+class MyChemESQueryPipeline(AsyncESQueryPipeline):
+    """Prefer authoritative DrugBank IDs while retaining xref fallbacks."""
+
+    async def fetch(self, id, **options):
+        result = await super().fetch(id, **options)
+
+        if isinstance(id, list):
+            primary_queries = {
+                document.get("query")
+                for document in result
+                if isinstance(document, dict)
+                and _drugbank_id(document.get("query"))
+                and _has_primary_drugbank_id(
+                    document, _drugbank_id(document.get("query"))
+                )
+            }
+            if not primary_queries:
+                return result
+            return [
+                document
+                for document in result
+                if document.get("query") not in primary_queries
+                or _has_primary_drugbank_id(
+                    document, _drugbank_id(document.get("query"))
+                )
+            ]
+
+        identifier = _drugbank_id(id)
+        if not identifier or not isinstance(result, list):
+            return result
+
+        primary_matches = [
+            document
+            for document in result
+            if _has_primary_drugbank_id(document, identifier)
+        ]
+        if len(primary_matches) == 1:
+            return primary_matches[0]
+        return primary_matches or result
 
 
 class MyChemESResultFormatter(ESResultFormatter):

--- a/src/web/pipeline.py
+++ b/src/web/pipeline.py
@@ -45,24 +45,24 @@ class MyChemESQueryPipeline(AsyncESQueryPipeline):
         result = await super().fetch(id, **options)
 
         if isinstance(id, list):
-            primary_queries = {
-                document.get("query")
-                for document in result
-                if isinstance(document, dict)
-                and _drugbank_id(document.get("query"))
-                and _has_primary_drugbank_id(
-                    document, _drugbank_id(document.get("query"))
-                )
-            }
+            primary_queries = set()
+            primary_result_indexes = set()
+            for index, document in enumerate(result):
+                if not isinstance(document, dict):
+                    continue
+                query = document.get("query")
+                identifier = _drugbank_id(query)
+                if identifier and _has_primary_drugbank_id(document, identifier):
+                    primary_queries.add(query)
+                    primary_result_indexes.add(index)
+
             if not primary_queries:
                 return result
             return [
                 document
-                for document in result
+                for index, document in enumerate(result)
                 if document.get("query") not in primary_queries
-                or _has_primary_drugbank_id(
-                    document, _drugbank_id(document.get("query"))
-                )
+                or index in primary_result_indexes
             ]
 
         identifier = _drugbank_id(id)


### PR DESCRIPTION
## Summary

- add `drugbank.id` to DrugBank identifier scopes and add DRUGBANK CURIE support
- prefer an exact authoritative `drugbank.id` match when both a primary record and cross-reference records are returned
- preserve the established UniChem, ChEBI, DrugCentral, and PharmGKB fallback behavior when no primary DrugBank record exists
- cover bare IDs, DRUGBANK CURIEs, fallback-only IDs, and batch annotation requests

## Root cause and impact

DrugBank lookups consulted only cross-reference fields. When multiple stereochemical records shared a UniChem DrugBank assertion, annotation could return a sparse record without DrugBank data instead of the record that owns the primary ID.

Field order alone does not create priority in an Elasticsearch multi-field query. The app-level preference step now selects an exact primary match from the normal result set and otherwise returns the pre-existing cross-reference results unchanged.

## Validation

- Python compilation
- isolated async pipeline tests for primary preference, cross-reference fallback, and batch behavior
- application regression fixtures for GET and POST
- GitHub Actions application matrix pending for Python 3.8–3.12

Closes #199